### PR TITLE
Json serialization ( #45 )

### DIFF
--- a/osbrain/address.py
+++ b/osbrain/address.py
@@ -186,7 +186,7 @@ class AgentAddressSerializer(str):
         Serializer type (i.e.: 'raw', 'pickle'...).
     """
     def __new__(cls, value):
-        if value not in ('raw', 'pickle'):
+        if value not in ('raw', 'pickle', 'json'):
             raise ValueError('Invalid serializer type %s!' % value)
         return super().__new__(cls, value)
 

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -302,7 +302,7 @@ class Agent():
 
     def ping(self):
         """
-        A simple ping method testing purposes.
+        A simple ping method (for testing purposes).
         """
         return 'pong'
 
@@ -789,6 +789,20 @@ class Agent():
                                 serializer)
 
     def _process_sub_message(self, serializer, message):
+        """
+        Return the received message in a PUBSUB communication.
+
+        Parameters
+        ----------
+        message : bytes
+            Received message without any treatment. Note that we do not know
+            whether there is a topic or not.
+
+        Returns
+        -------
+        anything
+            The content of the message passed.
+        """
         if serializer == 'pickle':
             # Since SUB messages might have a `topic`, we need to be careful to
             # only deserialize the non-topic part. Pickle objects always start
@@ -853,7 +867,10 @@ class Agent():
 
     def send(self, address, message, topic=''):
         """
-        TODO
+        Send a message through the specified address.
+
+        Note that replies in a REQREP pattern do not use this function in
+        order to be sent.
         """
         assert isinstance(topic, str), 'Topic must be of `str` type!'
         serializer = self.address[address].serializer
@@ -863,15 +880,28 @@ class Agent():
 
     def recv(self, address):
         """
-        TODO
+        Receive a message from the specified address.
 
         This method is only used in REQREP communication patterns.
+
+        Parameters
+        ----------
+        address :
+
+        Returns
+        -------
+        anything
+            The content received in the address.
+
         """
         message = self.socket[address].recv()
         serializer = self.address[address].serializer
         return deserialize_message(message=message, serializer=serializer)
 
     def send_recv(self, address, message):
+        """
+        This method is only used in REQREP communication patterns.
+        """
         self.send(address, message)
         return self.recv(address)
 

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -7,6 +7,7 @@ import inspect
 import multiprocessing
 import os
 import pickle
+import json
 import signal
 import sys
 import types
@@ -56,6 +57,8 @@ def serialize_message(message, serializer):
     """
     if serializer == 'pickle':
         return pickle.dumps(message, -1)
+    if serializer == 'json':
+        return str2bytes(json.dumps(message))
     if serializer == 'raw':
         return message
     raise ValueError('Serializer not supported for serialization')
@@ -81,6 +84,8 @@ def deserialize_message(message, serializer):
     """
     if serializer == 'pickle':
         return pickle.loads(message)
+    if serializer == 'json':
+        return json.loads(message)
     if serializer == 'raw':
         return message
     raise ValueError('Serializer not supported for deserialization')

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -28,6 +28,10 @@ from .proxy import Proxy
 from .proxy import NSProxy
 
 
+def str2bytes(message):
+    return message.encode('ascii')
+
+
 def serialize_message(message, serializer):
     """
     Check if a message needs to be serialized and do it if that is the
@@ -606,7 +610,7 @@ class Agent():
             handlers = {'': handlers}
         for topic in handlers.keys():
             assert isinstance(topic, str), 'Topic must be of type `str`!'
-            topic = self.str2bytes(topic)
+            topic = str2bytes(topic)
             self.socket[alias].setsockopt(zmq.SUBSCRIBE, topic)
         # Reset handlers
         self._set_handler(self.socket[alias], handlers)
@@ -812,7 +816,7 @@ class Agent():
         message = self._process_sub_message(serializer, serialized)
 
         for str_topic in handlers:
-            btopic = self.str2bytes(str_topic)
+            btopic = str2bytes(str_topic)
             if not serialized.startswith(btopic):
                 continue
             # Call the handler (with or without the topic)
@@ -848,9 +852,6 @@ class Agent():
 
         return serializer
 
-    def str2bytes(self, message):
-        return message.encode('ascii')
-
     def send(self, address, message, topic=''):
         """
         TODO
@@ -858,7 +859,7 @@ class Agent():
         assert isinstance(topic, str), 'Topic must be of `str` type!'
         serializer = self.address[address].serializer
         serialized = serialize_message(message=message, serializer=serializer)
-        topic = self.str2bytes(topic)
+        topic = str2bytes(topic)
         self.socket[address].send(topic + serialized)
 
     def recv(self, address):

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -37,6 +37,12 @@ def bytes2str(message):
     return message.decode('ascii')
 
 
+def check_type(x, check_type):
+    if not isinstance(x, check_type):
+        msg = 'Expected type `{}`, but got `{}`'.format(check_type, type(x))
+        raise TypeError(msg)
+
+
 def serialize_message(message, serializer):
     """
     Check if a message needs to be serialized and do it if that is the
@@ -67,8 +73,7 @@ def serialize_message(message, serializer):
     if result is None:
         raise ValueError('Serializer not supported for serialization')
 
-    if not isinstance(result, bytes):
-        raise TypeError('Must return `bytes`, not {}'.format(type(result)))
+    check_type(result, bytes)
 
     return result
 
@@ -91,8 +96,7 @@ def deserialize_message(message, serializer):
         The deserialized message, or the same message in case no
         deserialization is needed.
     """
-    if not isinstance(message, bytes):
-        raise TypeError('Expected `bytes`, but got {}'.format(type(message)))
+    check_type(message, bytes)
 
     result = None
 

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -32,6 +32,10 @@ def str2bytes(message):
     return message.encode('ascii')
 
 
+def bytes2str(message):
+    return message.decode('ascii')
+
+
 def serialize_message(message, serializer):
     """
     Check if a message needs to be serialized and do it if that is the

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -758,8 +758,7 @@ class Agent():
     def _process_rep_event(self, socket_kind, socket, handler_return,
                            serializer):
         if socket_kind == 'REP' and handler_return is not None:
-            if serializer == 'pickle':
-                handler_return = pickle.dumps(handler_return, -1)
+            handler_return = serialize_message(handler_return, serializer)
             socket.send(handler_return)
 
     def _process_nonsub_event(self, socket_kind, socket, serialized):

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -173,6 +173,44 @@ def test_socket_creation(nsaddr):
     assert 'alias2' in addresses
 
 
+def test_correct_serialization(nsaddr):
+    """
+    Test that the right serializer is being used when using the different
+    initialization options.
+    """
+    # Without specifying a serializer
+    a0 = run_agent('a0')
+    addr0 = a0.bind('PUB', 'alias0')
+    _address = a0.get_attr('address')
+    assert _address[addr0].serializer \
+        == os.getenv('OSBRAIN_DEFAULT_SERIALIZER')
+
+    # Specifying a serializer at Agent level
+    # Test is twice with different serializer to avoid collision with the
+    # environment variable
+    a1 = run_agent('a1', serializer='raw')
+    addr1 = a1.bind('PUB', 'alias1')
+    _address = a1.get_attr('address')
+    assert _address[addr1].serializer == 'raw'
+
+    a2 = run_agent('a2', serializer='pickle')
+    addr2 = a2.bind('PUB', 'alias2')
+    _address = a2.get_attr('address')
+    assert _address[addr2].serializer == 'pickle'
+
+    # Specifying a serializer at Socket level
+    # Test is twice with different serializer to avoid collision with the
+    # environment variable
+    a3 = run_agent('a3')
+    addr3 = a3.bind('PUB', 'alias3', serializer='raw')
+    _address = a3.get_attr('address')
+    assert _address[addr3].serializer == 'raw'
+    a4 = run_agent('a4')
+    addr4 = a4.bind('PUB', 'alias4', serializer='json')
+    _address = a4.get_attr('address')
+    assert _address[addr4].serializer == 'json'
+
+
 def test_reqrep(nsaddr):
     """
     Simple request-reply pattern between two agents.

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -6,7 +6,6 @@ import time
 import random
 from uuid import uuid4
 from threading import Timer
-import pickle
 
 import pytest
 
@@ -18,7 +17,6 @@ from osbrain import AgentProcess
 from osbrain import Proxy
 from osbrain import NSProxy
 from osbrain import SocketAddress
-from osbrain.agent import compose_message
 
 from common import nsaddr  # pragma: no flakes
 from common import nsproxy  # pragma: no flakes
@@ -35,26 +33,6 @@ def sync_agent_logger(agent, logger):
         time.sleep(0.01)
     while message not in logger.get_attr('log_history_info')[-1]:
         time.sleep(0.01)
-
-
-def test_message_composer():
-    msg_1 = b'Chain of bytes'
-    msg_2 = [1, 3, "Hello"]
-    topic = "test topic"
-    topic_bytes = b"test topic"
-
-    # Test raw serialization composing
-    assert compose_message('raw', msg_1) == b'Chain of bytes'
-    assert compose_message('raw', msg_1, topic) == b'test topicChain of bytes'
-
-    # Test pickle serialization composing
-    assert compose_message('pickle', msg_1) == pickle.dumps(msg_1, -1)
-    assert compose_message('pickle', msg_2) == pickle.dumps(msg_2, -1)
-
-    assert compose_message('pickle', msg_1, topic) \
-        == topic_bytes + pickle.dumps(msg_1, -1)
-    assert compose_message('pickle', msg_2, topic) \
-        == topic_bytes + pickle.dumps(msg_2, -1)
 
 
 def logger_received(logger, log_name, message, timeout=1.):

--- a/osbrain/tests/test_agent_pubsub_topics.py
+++ b/osbrain/tests/test_agent_pubsub_topics.py
@@ -82,6 +82,78 @@ def test_pubsub_topics_pickle(nsaddr):
     assert message_04 in a5.get_attr('received_list')
 
 
+def test_pubsub_topics_json(nsaddr):
+    """
+    Simple publisher-subscriber pattern test.
+
+    Different messages sent with different agents subscribed to different
+    topics are tested within this method.
+    """
+    a0 = run_agent('a0')
+    a1 = run_agent('a1')
+    a2 = run_agent('a2')
+    a3 = run_agent('a3')
+    a4 = run_agent('a4')
+    a5 = run_agent('a5')
+
+    for agent in (a1, a2, a3, a4, a5):
+        agent.set_attr(received_list=[])
+
+    addr = a0.bind('PUB', alias='pub', serializer='json')
+
+    a1.connect(addr, handler=log_received_to_list)
+    a2.connect(addr, handler={'foo': log_received_to_list})
+    a3.connect(addr, handler={'bar': log_received_to_list,
+                              'foo': log_received_to_list})
+    a4.connect(addr, handler={'bar': log_received_to_list})
+    a5.connect(addr, handler={'fo': log_received_to_list})
+
+    # Give some time for all the agents to connect
+    time.sleep(0.1)
+
+    # Send some messages
+    message_01 = 'Hello'
+    a0.send('pub', message_01)
+
+    message_02 = 'World'
+    a0.send('pub', message_02, topic='foo')
+
+    message_03 = 'FOO'
+    a0.send('pub', message_03, topic='foobar')
+
+    message_04 = 'BAR'
+    a0.send('pub', message_04, topic='fo')
+
+    # Give some time for all the agents to handle the message
+    time.sleep(0.1)
+
+    # Check each agent received the corresponding messages
+    assert message_01 in a1.get_attr('received_list')
+    assert message_02 in a1.get_attr('received_list')
+    assert message_03 in a1.get_attr('received_list')
+    assert message_04 in a1.get_attr('received_list')
+
+    assert message_01 not in a2.get_attr('received_list')
+    assert message_02 in a2.get_attr('received_list')
+    assert message_03 in a2.get_attr('received_list')
+    assert message_04 not in a2.get_attr('received_list')
+
+    assert message_01 not in a3.get_attr('received_list')
+    assert message_02 in a3.get_attr('received_list')
+    assert message_03 in a3.get_attr('received_list')
+    assert message_04 not in a3.get_attr('received_list')
+
+    assert message_01 not in a4.get_attr('received_list')
+    assert message_02 not in a4.get_attr('received_list')
+    assert message_03 not in a4.get_attr('received_list')
+    assert message_04 not in a4.get_attr('received_list')
+
+    assert message_01 not in a5.get_attr('received_list')
+    assert message_02 in a5.get_attr('received_list')
+    assert message_03 in a5.get_attr('received_list')
+    assert message_04 in a5.get_attr('received_list')
+
+
 def test_pubsub_topics_raw(nsaddr):
     """
     Simple publisher-subscriber pattern test.

--- a/osbrain/tests/test_agent_serialization.py
+++ b/osbrain/tests/test_agent_serialization.py
@@ -57,13 +57,23 @@ def test_serialize_message():
     """
     Test basic serialization.
     """
+    # Raw serialization
     test = b'asdf'
     assert test == serialize_message(message=test, serializer='raw')
+
+    # Pickle serialization
     test = [0, 1]
     assert test == pickle.loads(serialize_message(message=test,
                                 serializer='pickle'))
+
+    # Json serialization
     assert test == json.loads(serialize_message(message=test,
                               serializer='json').decode('ascii'))
+    # Un-serializable type
+    with pytest.raises(TypeError):
+        serialize_message(message=b'Hello', serializer='json')
+
+    # Incorrect serializer
     with pytest.raises(ValueError):
         serialize_message(message=test, serializer='foo')
 
@@ -72,13 +82,28 @@ def test_deserialize_message():
     """
     Test basic deserialization.
     """
+    # Raw deserialization
     test = b'asdf'
     assert test == deserialize_message(message=test, serializer='raw')
+
+    # Pickle deserialization
     test = [0, 1]
     assert test == deserialize_message(message=pickle.dumps(test, -1),
                                        serializer='pickle')
+
+    # Json deserialization
     assert test == deserialize_message(message=json.dumps(test).encode('ascii'),
                                        serializer='json')
+
+    # Wrong type
+    with pytest.raises(TypeError):
+        deserialize_message(message='Hello', serializer='raw')
+    with pytest.raises(TypeError):
+        deserialize_message(message=[1, 2, 3], serializer='pickle')
+    with pytest.raises(TypeError):
+        deserialize_message(message=None, serializer='json')
+
+    # Incorrect serializer
     with pytest.raises(ValueError):
         deserialize_message(message=b'x', serializer='foo')
 

--- a/osbrain/tests/test_agent_serialization.py
+++ b/osbrain/tests/test_agent_serialization.py
@@ -92,8 +92,9 @@ def test_deserialize_message():
                                        serializer='pickle')
 
     # Json deserialization
-    assert test == deserialize_message(message=json.dumps(test).encode('ascii'),
-                                       serializer='json')
+    assert test == \
+        deserialize_message(message=json.dumps(test).encode('ascii'),
+                            serializer='json')
 
     # Wrong type
     with pytest.raises(TypeError):

--- a/osbrain/tests/test_agent_serialization.py
+++ b/osbrain/tests/test_agent_serialization.py
@@ -24,6 +24,8 @@ def test_message_composer():
     topic = "test topic"
     topic_bytes = b"test topic"
 
+    separator = b'\x80'
+
     # Test raw serialization composing
     assert compose_message('raw', msg_1) == b'Chain of bytes'
     assert compose_message('raw', msg_1, topic) == b'test topicChain of bytes'
@@ -33,9 +35,9 @@ def test_message_composer():
     assert compose_message('pickle', msg_2) == pickle.dumps(msg_2, -1)
 
     assert compose_message('pickle', msg_1, topic) \
-        == topic_bytes + pickle.dumps(msg_1, -1)
+        == topic_bytes + separator + pickle.dumps(msg_1, -1)
     assert compose_message('pickle', msg_2, topic) \
-        == topic_bytes + pickle.dumps(msg_2, -1)
+        == topic_bytes + separator + pickle.dumps(msg_2, -1)
 
     # Test json serialization composing
     msg_1_str = 'Chain of bytes'
@@ -46,9 +48,9 @@ def test_message_composer():
         == json.dumps(msg_2).encode('ascii')
 
     assert compose_message('json', msg_1_str, topic) \
-        == topic_bytes + json.dumps(msg_1_str).encode('ascii')
+        == topic_bytes + separator + json.dumps(msg_1_str).encode('ascii')
     assert compose_message('json', msg_2, topic) \
-        == topic_bytes + json.dumps(msg_2).encode('ascii')
+        == topic_bytes + separator + json.dumps(msg_2).encode('ascii')
 
 
 def test_serialize_message():

--- a/osbrain/tests/test_agent_serialization.py
+++ b/osbrain/tests/test_agent_serialization.py
@@ -77,7 +77,7 @@ def test_deserialize_message():
     test = [0, 1]
     assert test == deserialize_message(message=pickle.dumps(test, -1),
                                        serializer='pickle')
-    assert test == deserialize_message(message=json.dumps(test),
+    assert test == deserialize_message(message=json.dumps(test).encode('ascii'),
                                        serializer='json')
     with pytest.raises(ValueError):
         deserialize_message(message=b'x', serializer='foo')


### PR DESCRIPTION
I have been working on adding `json` serialization (related to #45  ) as well as on making the process for adding new serialization options easier.

However, there are still a few things missing:
- Docummentation and examples.
- The separator for identifying the topic and the message in PUBSUB communication is hardcoded to "b'\x80'". Perhaps it would make sense to be configurable (per agent/socket)? (Note that the separator should only used in the PUBSUB pattern when the serialization is NOT raw and there is a topic.