### PR TITLE
Add context managers for AgentProcess

### DIFF
--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -1099,6 +1099,16 @@ class AgentProcess(multiprocessing.Process):
         self.sigint = True
         self.kill()
 
+    def __enter__(self):
+        self.start()
+        proxy = Proxy(self.name, self.nsaddr)
+        proxy.run()
+        return proxy
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.kill()
+        self.join()
+
 
 def run_agent(name, nsaddr=None, addr=None, base=Agent, serializer=None):
     """

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -71,6 +71,18 @@ def test_ping(nsaddr):
     assert a0.ping() == 'pong'
 
 
+def test_context_manager(nsaddr):
+    with AgentProcess('a0', nsaddr) as ap:
+        assert ap.ping() == 'pong'
+
+    class NewAgent(Agent):
+        def f(self):
+            return 123
+
+    with AgentProcess('a0', nsaddr, base=NewAgent) as ap:
+        assert ap.f() == 123
+
+
 def test_agent_shutdown(nsaddr):
     """
     An agent must unregister itself before shutting down.


### PR DESCRIPTION
Perhaps context managers could help us with the problems we are having in #59 . 

The problem is that as of now, we need to join the process so as for it to get removed from the process table, as it can be seen in `test_agent_shutdown` under `test_agent.py`.

Maybe the use of a context manager could replace at some point the run_agent function.

I'm in the process of further investigating the issue, so do not merge this branch yet, please.