### PR TITLE
Remove ready method from agent, since it is the same than ping

### DIFF
--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -400,12 +400,6 @@ class Agent():
         """
         return list(self._timer.keys())
 
-    def ping(self):
-        """
-        A simple ping method (for testing purposes).
-        """
-        return 'pong'
-
     def raise_exception(self):
         """
         Raise an exception (for testing purposes).
@@ -1233,12 +1227,12 @@ class Agent():
                 continue
             self.socket[address].close()
 
-    def ready(self):
+    def ping(self):
         """
         A test method to check the readiness of the agent. Used for testing
         purposes, where timing is very important. Do not remove.
         """
-        return 'OK'
+        return 'pong'
 
 
 class AgentProcess(multiprocessing.Process):

--- a/osbrain/proxy.py
+++ b/osbrain/proxy.py
@@ -90,7 +90,7 @@ class Proxy(Pyro4.core.Proxy):
             exception.
         """
         try:
-            self.ready()
+            self.unsafe.ping()
         except Exception:
             if time.time() - time0 < timeout:
                 return False
@@ -172,8 +172,7 @@ class Proxy(Pyro4.core.Proxy):
         """
         return (methodname in self._pyroMethods and
                 not methodname.startswith('_') and
-                methodname not in ('ready', 'run', 'get_attr', 'kill',
-                                   'safe_call'))
+                methodname not in ('run', 'get_attr', 'kill', 'safe_call'))
 
     def _remote_call(self, methodname, args, kwargs, flags, objectId):
         """

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -50,7 +50,7 @@ def test_early_agent_proxy(nsaddr):
     # Locate agent now
     a0 = Proxy('a0', timeout=3.)
     # Just check agent is ready
-    assert a0.ready() == 'OK'
+    assert a0.unsafe.ping() == 'pong'
 
 
 def test_agent_loopback(nsaddr):

--- a/osbrain/tests/test_nameserver.py
+++ b/osbrain/tests/test_nameserver.py
@@ -22,7 +22,7 @@ from common import nsproxy  # pragma: no flakes
 
 def test_nameserver_ping(nsproxy):
     """
-    Ping name server.
+    Simple name server ping test.
     """
     assert nsproxy.ping() == 'pong'
 

--- a/osbrain/tests/test_proxy.py
+++ b/osbrain/tests/test_proxy.py
@@ -111,7 +111,7 @@ def test_agent_proxy_initialization_timeout(nsproxy):
     is not ready after a number of seconds.
     """
     class InitTimeoutProxy(Proxy):
-        def ready(self):
+        def ping(self):
             time.sleep(0.1)
             raise TimeoutError()
 


### PR DESCRIPTION
I noticed than `Agent.ready()` and `Agent.ping()` were basically doing the same thing.