### PR TITLE
Use thread instead of multiplex Pyro server

### DIFF
--- a/osbrain/__init__.py
+++ b/osbrain/__init__.py
@@ -4,7 +4,7 @@ Pyro4.config.SERIALIZERS_ACCEPTED.add('pickle')
 Pyro4.config.SERIALIZERS_ACCEPTED.add('dill')
 Pyro4.config.SERIALIZER = 'dill'
 Pyro4.config.THREADPOOL_SIZE = 16
-Pyro4.config.SERVERTYPE = 'multiplex'
+Pyro4.config.SERVERTYPE = 'thread'
 Pyro4.config.REQUIRE_EXPOSE = False
 Pyro4.config.COMMTIMEOUT = 0.
 Pyro4.config.DETAILED_TRACEBACK = True

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -209,8 +209,6 @@ class Agent():
         self.keep_alive = True
         self._shutdown_now = False
         self.running = False
-        # Kill parent AgentProcess
-        self.kill_agent = False
         self._DEBUG = False
 
         self.context = zmq.Context()
@@ -1219,7 +1217,7 @@ class Agent():
 
     def kill(self):
         self.close_sockets()
-        self.kill_agent = True
+        self._pyroDaemon.shutdown()
 
     def close_sockets(self):
         for address in self.socket:
@@ -1274,8 +1272,7 @@ class AgentProcess(multiprocessing.Process):
         ns.register(self.name, uri)
         ns.release()
 
-        self.daemon.requestLoop(lambda: (not self.shutdown_event.is_set() and
-                                         not self.agent.kill_agent))
+        self.daemon.requestLoop(lambda: not self.shutdown_event.is_set())
         self.daemon.unregister(self.agent)
 
         self._teardown()

--- a/osbrain/nameserver.py
+++ b/osbrain/nameserver.py
@@ -20,7 +20,6 @@ from .proxy import NSProxy
 class NameServer(Pyro4.naming.NameServer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.shutdown_parent_daemon = False
 
     def ping(self):
         """
@@ -53,7 +52,7 @@ class NameServer(Pyro4.naming.NameServer):
         Shutdown the name server. All agents will be shutdown as well.
         """
         self.async_shutdown_agents()
-        self.shutdown_parent_daemon = True
+        self._pyroDaemon.shutdown()
 
 
 Pyro4.naming.NameServer = NameServer
@@ -97,10 +96,7 @@ class NameServerProcess(multiprocessing.Process):
         print("NS running on %s (%s)" % (self.daemon.locationStr, hostip))
         print("URI = %s" % self.uri)
         try:
-            self.daemon.requestLoop(
-                lambda: (not self.shutdown_event.is_set() and
-                         not self.daemon.nameserver.shutdown_parent_daemon)
-            )
+            self.daemon.requestLoop(lambda: not self.shutdown_event.is_set())
         finally:
             self.daemon.close()
             if bcserver is not None:

--- a/osbrain/nameserver.py
+++ b/osbrain/nameserver.py
@@ -43,7 +43,7 @@ class NameServer(Pyro4.naming.NameServer):
                 continue
             agent = Pyro4.core.Proxy(address)
             if agent.get_attr('running'):
-                agent.shutdown()
+                agent.after(0, 'shutdown')
             else:
                 agent.kill()
 

--- a/osbrain/tests/test_nameserver.py
+++ b/osbrain/tests/test_nameserver.py
@@ -110,7 +110,7 @@ def test_nameserverprocess_shutdown_lazy_agents():
 
     t0 = time.time()
     nsprocess.shutdown()
-    assert time.time() - t0 > 2
+    assert time.time() - t0 > 1
 
 
 def test_nameserver_proxy_timeout():


### PR DESCRIPTION
Initial implementation, still investigating better ways to successfully shutdown in both cases.

Should fix #6.