### PR TITLE
Add some leeway in test_yield for consistency

### DIFF
--- a/osbrain/tests/test_agent_req_rep.py
+++ b/osbrain/tests/test_agent_req_rep.py
@@ -63,7 +63,7 @@ def test_yield(nsproxy):
     assert response == 'Working!'
     assert a0.get_attr('delay') == delay
     # Sleep so that the replier has had time to update
-    time.sleep(delay)
+    time.sleep(delay + 0.5)
     assert a0.get_attr('delay') == 'ok'
 
 


### PR DESCRIPTION
This test can fail as in https://travis-ci.org/opensistemas-hub/osbrain/jobs/213462714

I added an extra 0.5 second delay so as to make it pass more consistently.