### PR TITLE
Implement test for `wait_agent_attr` function

### DIFF
--- a/osbrain/tests/common.py
+++ b/osbrain/tests/common.py
@@ -87,11 +87,49 @@ def agent_dies(agent, nsproxy, timeout=1.):
     return True
 
 
-def wait_agent_list(agent, name='received', length=None, data=None,
+def attribute_match(attribute, length=None, data=None, value=None):
+    """
+    Check if an attribute matches any condition:
+
+    - Minimum length.
+    - Contains an item.
+    - Is exactly a value.
+
+    Parameters
+    ----------
+    attribute : anything
+        The attribute to match against.
+    length : int, default is None
+        Return True if the attribute has this minimum length.
+    data : anything, default is None
+        Return True if the attribute contains this value.
+    value : anything, default is None
+        Return True if the attribute contains this value.
+
+    Returns
+    -------
+    bool
+        Whether the attribute matches any condition.
+    """
+    assert length is not None or data is not None or value is not None, \
+        'No condition passed! will return False always...'
+    if length is not None and len(attribute) >= length:
+        return True
+    if data is not None and data in attribute:
+        return True
+    if value is not None and attribute == value:
+        return True
+    return False
+
+
+def wait_agent_attr(agent, name='received', length=None, data=None, value=None,
                     timeout=3):
     """
-    Wait for an agent's attribute, which is a list, to contain a particular
-    item or to reach a particular size.
+    Wait for an agent's attribute, to:
+
+    - Reach a minimum length.
+    - Contain a particular item.
+    - Become a given value.
 
     Parameters
     ----------
@@ -102,18 +140,16 @@ def wait_agent_list(agent, name='received', length=None, data=None,
     length : int, default is None
         If specified, wait until the attribute reaches this length.
     data : anything, default is None
-        If scpecified, wait until the attribute contains this element.
+        If specified, wait until the attribute contains this element.
+    value : anything, default is None
+        If specified, wait until the attribute becomes this value.
     timeout : float, default is 3
         After this number of seconds the function will return `False`.
     """
-    assert length is not None or data is not None, \
-        'No condition passed, wait_agent_list will return False always'
     t0 = time.time()
     while True:
-        received = agent.get_attr(name)
-        if length is not None and len(received) >= length:
-            return True
-        if data is not None and data in received:
+        attribute = agent.get_attr(name)
+        if attribute_match(attribute, length=length, data=data, value=value):
             return True
         if time.time() - t0 > timeout:
             break

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -22,7 +22,7 @@ from common import nsproxy  # pragma: no flakes
 from common import agent_dies
 from common import logger_received
 from common import sync_agent_logger
-from common import wait_agent_list
+from common import wait_agent_attr
 
 
 def set_received(agent, message, topic=None):
@@ -238,7 +238,7 @@ def test_linger(nsproxy, linger_ms, sleep_time, should_receive):
     puller.bind('PULL', alias='pull', handler=receive, addr=address.address,
                 transport='tcp')
 
-    assert should_receive == wait_agent_list(puller, data='foo', timeout=.2)
+    assert should_receive == wait_agent_attr(puller, data='foo', timeout=.2)
 
 
 def test_pushpull(nsproxy):

--- a/osbrain/tests/test_agent_sync_publications.py
+++ b/osbrain/tests/test_agent_sync_publications.py
@@ -12,7 +12,7 @@ from osbrain import run_logger
 from common import nsproxy  # pragma: no flakes
 from common import sync_agent_logger
 from common import logger_received
-from common import wait_agent_list
+from common import wait_agent_attr
 
 
 class Server(Agent):
@@ -90,8 +90,8 @@ def test_simple_pub(nsproxy):
 
     # Wait for clients to receive some data
     N = 10
-    assert wait_agent_list(both, length=N)
-    assert wait_agent_list(positive, length=N)
+    assert wait_agent_attr(both, length=N)
+    assert wait_agent_attr(positive, length=N)
 
     # both
     received = [int(x) for x in both.get_attr('received')]
@@ -137,14 +137,14 @@ def test_request(nsproxy, server):
 
     # Wait for clients to receive some data
     N = 10
-    assert wait_agent_list(active, length=N)
-    assert wait_agent_list(passive, length=N)
+    assert wait_agent_attr(active, length=N)
+    assert wait_agent_attr(passive, length=N)
 
     # Send request from active client
     active.send('sub', 'request!', handler=receive_negate)
 
     # Server request processing
-    assert wait_agent_list(server, length=1)
+    assert wait_agent_attr(server, length=1)
     received = server.get_attr('received')
     assert len(received) == 1
     assert received[0][1] == 'request!'
@@ -152,7 +152,7 @@ def test_request(nsproxy, server):
 
     # Make sure active gets response
     N = len(active.get_attr('received')) + 2
-    assert wait_agent_list(active, length=N)
+    assert wait_agent_attr(active, length=N)
 
     # Check active client received data
     received = active.get_attr('received')
@@ -165,7 +165,7 @@ def test_request(nsproxy, server):
     assert received == list(range(received[0], received[-1] + 1))
 
     # Check passive client received data
-    assert wait_agent_list(passive, data=received[-1])
+    assert wait_agent_attr(passive, data=received[-1])
     received = passive.get_attr('received')
     assert -response not in received
     assert received == list(range(received[0], received[-1] + 1))
@@ -194,7 +194,7 @@ def test_wait(nsproxy):
 
     # Wait for client to receive some data
     N = 10
-    assert wait_agent_list(client, length=N)
+    assert wait_agent_attr(client, length=N)
 
     # Response received in time
     fast = 0
@@ -216,6 +216,6 @@ def test_wait(nsproxy):
     # Response not received in time with error handler
     slow = 1
     client.send('sub', slow, handler=receive, wait=0.1, on_error=on_error)
-    assert wait_agent_list(client, name='error_log', length=1, timeout=0.5)
+    assert wait_agent_attr(client, name='error_log', length=1, timeout=0.5)
     assert server.get_attr('received') == [fast, slow]
     assert 'x' + str(slow) not in client.get_attr('received')

--- a/osbrain/tests/test_test_common.py
+++ b/osbrain/tests/test_test_common.py
@@ -1,13 +1,18 @@
 """
 Test file for functionality implemented in `osbrain/tests/common.py`.
 """
+import pytest
+
 from osbrain import run_agent
 from osbrain import run_logger
+from osbrain import Agent
 
 from common import nsproxy  # pragma: no flakes
 from common import logger_received
 from common import sync_agent_logger
 from common import agent_dies
+from common import attribute_match
+from common import wait_agent_attr
 
 
 def test_agent_dies(nsproxy):
@@ -42,3 +47,42 @@ def test_logger_received(nsproxy):
     a0.set_logger(logger)
     sync_agent_logger(agent=a0, logger=logger)
     assert not logger_received(logger, 'log_history_error', message='asdf')
+
+
+@pytest.mark.parametrize('attribute,length,data,value,match', [
+    ([], 1, None, None, False),
+    ([], None, 1, None, False),
+    ([], None, None, [], True),
+    ({'foo'}, 1, None, None, True),
+    ({'foo'}, None, 'foo', None, True),
+    ({'foo'}, None, None, {'foo'}, True),
+    (42, None, None, 14, False),
+    (42, None, None, 42, True),
+])
+def test_attribute_match(attribute, length, data, value, match):
+    """
+    Test `attribute_match` function.
+    """
+    result = attribute_match(attribute, length=length, data=data, value=value)
+    assert result == match
+
+
+def test_wait_agent_attr(nsproxy):
+    """
+    Test `wait_agent_attr` function.
+    """
+    class Client(Agent):
+        def set_received(self, value):
+            self.received = value
+
+    a0 = run_agent('a0', base=Client)
+
+    # Named attribute, zero timeout
+    a0.set_attr(x=[])
+    assert not wait_agent_attr(a0, 'x', length=1, timeout=0.)
+
+    # Default attribute, timeout
+    a0.set_attr(received=0)
+    a0.after(1, 'set_received', 42)
+    assert not wait_agent_attr(a0, value=42, timeout=0.)
+    assert wait_agent_attr(a0, value=42, timeout=2.)


### PR DESCRIPTION
I changed the function to be a bit more general, too. Now you can also use it to check that an attribute ends up with a given value (we don't assume it is necessarily a list anymore).