### PR TITLE
Allow agents and name servers to spawn child processes

### DIFF
--- a/osbrain/__init__.py
+++ b/osbrain/__init__.py
@@ -37,7 +37,7 @@ config['IPC_DIR'].mkdir(exist_ok=True, parents=True)
 __version__ = '0.4.2'
 
 from .agent import Agent, AgentProcess, run_agent
-from .nameserver import run_nameserver
+from .nameserver import NameServer, run_nameserver
 from .proxy import Proxy, NSProxy
 from .address import SocketAddress, AgentAddress
 from .logging import Logger, run_logger

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -1,6 +1,7 @@
 """
 Test file for agents.
 """
+import multiprocessing
 import time
 from uuid import uuid4
 from threading import Timer
@@ -536,3 +537,20 @@ def test_agent_stop(nsproxy):
     while agent.get_attr('running'):
         time.sleep(0.01)
     assert not agent.get_attr('running')
+
+
+def test_agent_spawn_process(nsproxy):
+    """
+    An agent should be able to spawn child processes.
+
+    It is a way to make sure agents are run as non-daemonic processes, which
+    are not allowed to have children.
+    """
+    class Spawner(Agent):
+        def spawn_process(self):
+            p = multiprocessing.Process()
+            p.start()
+            return True
+
+    agent = run_agent('a0', base=Spawner)
+    assert agent.spawn_process()

--- a/osbrain/tests/test_nameserver.py
+++ b/osbrain/tests/test_nameserver.py
@@ -12,6 +12,7 @@ from osbrain import SocketAddress
 from osbrain import run_agent
 from osbrain import run_nameserver
 from osbrain import Agent
+from osbrain import NameServer
 from osbrain import NSProxy
 from osbrain.nameserver import NameServerProcess
 from osbrain.nameserver import random_nameserver_process
@@ -231,3 +232,17 @@ def test_nameserver_permissionerror():
         run_nameserver('127.0.0.1:22')
     assert 'PermissionError' in str(error.value)
     assert 'Permission denied' in str(error.value)
+
+
+def test_run_nameserver_base():
+    """
+    The `run_nameserver` function should accept a `base` parameter to specify
+    the base NameServer class.
+    """
+    class BobMarley(NameServer):
+        def get_up(self):
+            return 'stand up!'
+
+    ns = run_nameserver(base=BobMarley)
+    assert ns.get_up() == 'stand up!'
+    ns.shutdown()

--- a/osbrain/tests/test_nameserver.py
+++ b/osbrain/tests/test_nameserver.py
@@ -4,6 +4,7 @@ Test file for nameserver.
 import os
 import time
 import random
+import multiprocessing
 from threading import Timer
 
 import pytest
@@ -245,4 +246,22 @@ def test_run_nameserver_base():
 
     ns = run_nameserver(base=BobMarley)
     assert ns.get_up() == 'stand up!'
+    ns.shutdown()
+
+
+def test_nameserver_spawn_process(nsproxy):
+    """
+    A name server should be able to spawn child processes.
+
+    It is a way to make sure name servers are run as non-daemonic processes,
+    which are not allowed to have children.
+    """
+    class Spawner(NameServer):
+        def spawn_process(self):
+            p = multiprocessing.Process()
+            p.start()
+            return True
+
+    ns = run_nameserver(base=Spawner)
+    assert ns.spawn_process()
     ns.shutdown()


### PR DESCRIPTION
This implements basic inception capabilities. There is no API defined for explicitly running agents and handling children processes (currently that would be the user's responsibility). That should probably be discussed in a new issue.