### PR TITLE
Fix Proxy serialization and update Pyro4 requirements

### DIFF
--- a/osbrain/proxy.py
+++ b/osbrain/proxy.py
@@ -105,7 +105,7 @@ class Proxy(Pyro4.core.Proxy):
             (self._next_oneway, self._default_safe, self._safe)
 
     def __setstate__(self, state):
-        super().__setstate__(state)
+        super().__setstate__(state[:-3])
         self._next_oneway = state[-3]
         self._default_safe = state[-2]
         self._safe = state[-1]

--- a/osbrain/tests/test_proxy.py
+++ b/osbrain/tests/test_proxy.py
@@ -3,6 +3,7 @@ Proxy module tests.
 """
 import time
 
+import pickle
 import pytest
 
 import osbrain
@@ -108,6 +109,20 @@ def test_proxy_without_nsaddr(nsproxy):
     agent0.set_attr(x=1.)
     agent1 = Proxy('foo')
     assert agent1.get_attr('x') == 1.
+
+
+def test_proxy_pickle_serialization(nsproxy):
+    """
+    Make sure proxies can be (de)serialized using pickle.
+    """
+    agent0 = run_agent('foo')
+    agent0.set_attr(x=1.)
+    proxy = Proxy('foo')
+    serialized = pickle.dumps(proxy)
+    assert serialized
+    deserialized = pickle.loads(serialized)
+    assert deserialized
+    assert deserialized.get_attr('x') == 1.
 
 
 def test_agent_proxy_remote_exceptions(nsproxy):

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     keywords='osbrain multi-agent system',
     packages=['osbrain'],
     install_requires=[
-        'Pyro4>=4.42',
+        'Pyro4>=4.48',
         'pyzmq>=15.2.0',
         'dill>=0.2.0',
     ] + install_requires_compat,


### PR DESCRIPTION
Proxy serialization was broken for Pyro4 4.47 or inferior (incorrect serialization). That problem is fixed and a test has been added.

Anyway the test suite breaks for Pyro4 4.47 or inferior still, so the minimum required version has been risen from 4.42 to 4.48.