### PR TITLE
ASYNC_REQ/SYNC_PUB server handler tests

### DIFF
--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -670,6 +670,7 @@ class Agent():
             The channel where the agent binded to.
         """
         if kind == 'ASYNC_REP':
+            assert handler is not None, 'This socket requires a handler!'
             socket = self.context.socket(zmq.PULL)
             addr = self._bind_socket(socket, addr=addr, transport=transport)
             server_address = AgentAddress(transport, addr, 'PULL', 'server',


### PR DESCRIPTION
This PR should be considered only if #129 ends up merged. These tests will focus on making sure `handler` managing is correct when binding the ASYNC_REQ/SYNC_PUB servers.