### PR TITLE
Handler validation raise instead of assert

### DIFF
--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -25,6 +25,7 @@ from . import config
 from .common import format_exception
 from .common import format_method_exception
 from .common import unbound_method
+from .common import validate_handler
 from .common import LogLevel
 from .common import repeat
 from .common import after
@@ -633,8 +634,7 @@ class Agent():
         AgentAddress
             The address where the agent binded to.
         """
-        assert not kind.requires_handler() or handler is not None, \
-            'This socket requires a handler!'
+        validate_handler(handler, required=kind.requires_handler())
         socket = self.context.socket(kind.zmq())
         addr = self._bind_socket(socket, addr=addr, transport=transport)
         server_address = AgentAddress(transport, addr, kind, 'server',
@@ -670,7 +670,7 @@ class Agent():
             The channel where the agent binded to.
         """
         if kind == 'ASYNC_REP':
-            assert handler is not None, 'This socket requires a handler!'
+            validate_handler(handler, required=True)
             socket = self.context.socket(zmq.PULL)
             addr = self._bind_socket(socket, addr=addr, transport=transport)
             server_address = AgentAddress(transport, addr, 'PULL', 'server',
@@ -769,8 +769,8 @@ class Agent():
         assert server_address.role == 'server', \
             'Incorrect address! A server address must be provided!'
         client_address = server_address.twin()
-        assert not client_address.kind.requires_handler() or \
-            handler is not None, 'This socket requires a handler!'
+        validate_handler(handler,
+                         required=client_address.kind.requires_handler())
         if self.registered(client_address):
             self._connect_old(client_address, alias, handler)
         else:

--- a/osbrain/common.py
+++ b/osbrain/common.py
@@ -47,6 +47,14 @@ def format_method_exception(error, method, args, kwargs):
     return type(error)(message)
 
 
+def validate_handler(handler, required):
+    '''
+    Raises a ValueError exception when a required is handler but not present.
+    '''
+    if required and handler is None:
+        raise ValueError('This socket requires a handler!')
+
+
 class LogLevel(str):
     """
     Identifies the log level: ERROR, WARNING, INFO, DEBUG.

--- a/osbrain/tests/test_agent_async_requests_handlers.py
+++ b/osbrain/tests/test_agent_async_requests_handlers.py
@@ -42,7 +42,7 @@ def test_async_rep_handler_exists(nsproxy):
     '''
     server = run_agent('server', base=Agent)
 
-    with pytest.raises(AssertionError) as error:
+    with pytest.raises(ValueError) as error:
         server.bind('ASYNC_REP', alias='should_crash')
     assert 'This socket requires a handler!' in str(error.value)
 

--- a/osbrain/tests/test_agent_sync_publications_handlers.py
+++ b/osbrain/tests/test_agent_sync_publications_handlers.py
@@ -45,7 +45,7 @@ def test_sync_pub_handler_exists(nsproxy):
     '''
     server = run_agent('server', base=Agent)
 
-    with pytest.raises(AssertionError) as error:
+    with pytest.raises(ValueError) as error:
         server.bind('SYNC_PUB', alias='should_crash')
     assert 'This socket requires a handler!' in str(error.value)
 


### PR DESCRIPTION
This PR should be looked only after looking at #130, since the commit comes from that one. Extract the handler validation into a function that throws an exception instead of an assert, to guarantee it is always checked.