### PR TITLE
Finer topic handling

### DIFF
--- a/osbrain/address.py
+++ b/osbrain/address.py
@@ -389,7 +389,7 @@ class AgentChannel():
     receiver : str
         Second AgentAddress.
     """
-    def __init__(self, kind, receiver, sender):
+    def __init__(self, kind, receiver, sender, uuid=None):
         self.kind = AgentChannelKind(kind)
         self.receiver = receiver
         self.sender = sender
@@ -397,7 +397,7 @@ class AgentChannel():
             receiver.transport if receiver else sender.transport
         self.serializer = \
             receiver.serializer if receiver else sender.serializer
-        self.uuid = unique_identifier()
+        self.uuid = uuid or unique_identifier()
         # Set up pairs
         if sender:
             self.sender.channel = self
@@ -435,4 +435,5 @@ class AgentChannel():
         kind = self.kind.twin()
         sender = self.receiver.twin() if self.receiver is not None else None
         receiver = self.sender.twin() if self.sender is not None else None
-        return self.__class__(kind=kind, receiver=receiver, sender=sender)
+        return self.__class__(kind=kind, receiver=receiver, sender=sender,
+                              uuid=self.uuid)

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -911,7 +911,7 @@ class Agent():
         '''
         if isinstance(self.address[socket], AgentAddress):
             self.socket[socket].setsockopt(zmq.UNSUBSCRIBE, topic)
-        if isinstance(self.address[socket], AgentChannel):
+        elif isinstance(self.address[socket], AgentChannel):
             channel = self.address[socket]
             socket = channel.receiver
             treated_topic = channel.uuid + topic
@@ -930,7 +930,7 @@ class Agent():
         '''
         if isinstance(self.address[socket], AgentAddress):
             self.socket[socket].setsockopt(zmq.SUBSCRIBE, topic)
-        if isinstance(self.address[socket], AgentChannel):
+        elif isinstance(self.address[socket], AgentChannel):
             channel = self.address[socket]
             socket = channel.receiver
             treated_topic = channel.uuid + topic

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -899,7 +899,7 @@ class Agent():
         return client_address
 
     def unsubscribe_from_topic(self,
-                               socket: Union[AgentAddress, str, zmq.Socket],
+                               socket: Union[AgentAddress, AgentChannel, str],
                                topic: Union[bytes, str]):
         '''
         Unsubscribe a socket from a given topic.
@@ -924,7 +924,8 @@ class Agent():
             treated_topic = channel.uuid + topic
             self.socket[socket].setsockopt(zmq.UNSUBSCRIBE, treated_topic)
 
-    def subscribe_to_topic(self, socket: Union[AgentAddress, str, zmq.Socket],
+    def subscribe_to_topic(self,
+                           socket: Union[AgentAddress, AgentChannel, str],
                            topic: Union[bytes, str]):
         '''
         Subscribe a socket to a given topic.

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -898,7 +898,7 @@ class Agent():
         self.register(socket, register_as, alias, handler)
         return client_address
 
-    def unsubscribe_socket_from_topic(self, socket, topic: bytes):
+    def unsubscribe_from_topic(self, socket, topic: bytes):
         '''
         Unsubscribe a socket from a given topic.
 
@@ -917,7 +917,7 @@ class Agent():
             treated_topic = channel.uuid + topic
             self.socket[socket].setsockopt(zmq.UNSUBSCRIBE, treated_topic)
 
-    def subscribe_socket_to_topic(self, socket, topic: bytes):
+    def subscribe_to_topic(self, socket, topic: bytes):
         '''
         Subscribe a socket to a given topic.
 
@@ -970,7 +970,7 @@ class Agent():
         curated_handlers = topics_to_bytes(handlers)
         # Subscribe to topics
         for topic in curated_handlers.keys():
-            self.subscribe_socket_to_topic(alias, topic)
+            self.subscribe_to_topic(alias, topic)
         # Reset handlers
         self._set_handler(self.socket[alias], curated_handlers)
 

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -898,7 +898,9 @@ class Agent():
         self.register(socket, register_as, alias, handler)
         return client_address
 
-    def unsubscribe_from_topic(self, socket, topic: bytes):
+    def unsubscribe_from_topic(self,
+                               socket: Union[AgentAddress, str, zmq.Socket],
+                               topic: bytes):
         '''
         Unsubscribe a socket from a given topic.
 
@@ -906,6 +908,8 @@ class Agent():
         ----------
         socket
             Identifier of the socket. Must be a valid entry of `self.socket`
+            for the PUB/SUB pattern and a valid entry of `self.address` for
+            the SYNC_PUB/SYNC_SUB pattern
         topic
             topic which we want to unsubscribe from
         '''
@@ -917,7 +921,8 @@ class Agent():
             treated_topic = channel.uuid + topic
             self.socket[socket].setsockopt(zmq.UNSUBSCRIBE, treated_topic)
 
-    def subscribe_to_topic(self, socket, topic: bytes):
+    def subscribe_to_topic(self, socket: Union[AgentAddress, str, zmq.Socket],
+                           topic: bytes):
         '''
         Subscribe a socket to a given topic.
 
@@ -925,6 +930,8 @@ class Agent():
         ----------
         socket
             Identifier of the socket. Must be a valid entry of `self.socket`
+            for the PUB/SUB pattern and a valid entry of `self.address` for
+            the SYNC_PUB/SYNC_SUB pattern
         topic
             topic which we want to subscribe to
         '''

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -900,7 +900,7 @@ class Agent():
 
     def unsubscribe_from_topic(self,
                                socket: Union[AgentAddress, str, zmq.Socket],
-                               topic: bytes):
+                               topic: Union[bytes, str]):
         '''
         Unsubscribe a socket from a given topic.
 
@@ -913,6 +913,9 @@ class Agent():
         topic
             topic which we want to unsubscribe from
         '''
+        if isinstance(topic, str):
+            topic = topic.encode()
+
         if isinstance(self.address[socket], AgentAddress):
             self.socket[socket].setsockopt(zmq.UNSUBSCRIBE, topic)
         elif isinstance(self.address[socket], AgentChannel):
@@ -922,7 +925,7 @@ class Agent():
             self.socket[socket].setsockopt(zmq.UNSUBSCRIBE, treated_topic)
 
     def subscribe_to_topic(self, socket: Union[AgentAddress, str, zmq.Socket],
-                           topic: bytes):
+                           topic: Union[bytes, str]):
         '''
         Subscribe a socket to a given topic.
 
@@ -935,6 +938,9 @@ class Agent():
         topic
             topic which we want to subscribe to
         '''
+        if isinstance(topic, str):
+            topic = topic.encode()
+
         if isinstance(self.address[socket], AgentAddress):
             self.socket[socket].setsockopt(zmq.SUBSCRIBE, topic)
         elif isinstance(self.address[socket], AgentChannel):

--- a/osbrain/tests/test_agent_sync_publications.py
+++ b/osbrain/tests/test_agent_sync_publications.py
@@ -74,7 +74,9 @@ def on_error(agent):
 
 
 @pytest.mark.parametrize('socket_type', ['PUB', 'SYNC_PUB'])
-def test_change_subscription_topics_sync(nsproxy, socket_type):
+@pytest.mark.parametrize('unsub, sub', [('', 'TOP'),
+                                        (b'', b'TOP')])
+def test_change_subscription_topics_sync(nsproxy, socket_type, unsub, sub):
     '''
     Test for the different options of subscribing/unsubscribing to topics
     in the SYNC_PUB/SYNC_SUB pattern.
@@ -95,8 +97,8 @@ def test_change_subscription_topics_sync(nsproxy, socket_type):
     assert wait_agent_attr(client, name='received', data='hello')
 
     # Only subscribe to 'TOP' topic
-    client.unsubscribe_from_topic('sub', b'')
-    client.subscribe_to_topic('sub', b'TOP')
+    client.unsubscribe_from_topic('sub', unsub)
+    client.subscribe_to_topic('sub', sub)
 
     # Message not received since 'TOP' topic not specified in the send call
     server.send('pub', 'world')

--- a/osbrain/tests/test_agent_sync_publications.py
+++ b/osbrain/tests/test_agent_sync_publications.py
@@ -95,8 +95,8 @@ def test_change_subscription_topics_sync(nsproxy, socket_type):
     assert wait_agent_attr(client, name='received', data='hello')
 
     # Only subscribe to 'TOP' topic
-    client.unsubscribe_socket_from_topic('sub', b'')
-    client.subscribe_socket_to_topic('sub', b'TOP')
+    client.unsubscribe_from_topic('sub', b'')
+    client.subscribe_to_topic('sub', b'TOP')
 
     # Message not received since 'TOP' topic not specified in the send call
     server.send('pub', 'world')


### PR DESCRIPTION
Use case: In osMarkets, we want to be able to subscribe to different topics after the `connect` call has been done by a client. Therefore, it will come in handy to be able to easily modify the topics a given SUB socket is subscribed to.

Note that this first implementation is only for direct PUB/SUB topics. I think for SYNC_PUB/SYNC_SUB channels, it will need a bit more work, but the idea would be the same. I will start working on the tests for that case right now, and will push to this PR when they are ready.