### PR TITLE
Fix typo and test coverage

### DIFF
--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -297,18 +297,19 @@ def test_agent_multiproxy(nsproxy):
 
 def test_set_logger(nsproxy):
     """
-    Setting an agent's logger should result in the agnet actually sending
+    Setting an agent's logger should result in the agent actually sending
     log messages to the logger.
     """
     logger = run_logger('logger')
     a0 = run_agent('a0')
     a0.set_logger(logger)
+
     message = 'Hello world'
-    while True:
-        a0.log_info(message)
-        history = logger.get_attr('log_history')
-        if len(history):
-            break
+    a0.each(0.1, 'log_info', message)
+
+    assert wait_agent_attr(logger, name='log_history', length=1)
+
+    history = logger.get_attr('log_history')
     assert message in history[0]
 
 


### PR DESCRIPTION
The test could ocassionally report a decrease in codecov since the if branch could sometimes only evaluate the `if True:` path.