### PR TITLE
Refactor tests

### DIFF
--- a/osbrain/tests/common.py
+++ b/osbrain/tests/common.py
@@ -6,6 +6,10 @@ from osbrain import run_nameserver
 from osbrain.helper import sync_agent_logger
 
 
+def receive(agent, message, topic=None):
+    agent.received.append(message)
+
+
 @pytest.fixture(scope='function')
 def nsproxy(request):
     ns = run_nameserver()

--- a/osbrain/tests/common.py
+++ b/osbrain/tests/common.py
@@ -10,6 +10,10 @@ def receive(agent, message, topic=None):
     agent.received.append(message)
 
 
+def set_received(agent, message, topic=None):
+    agent.received = message
+
+
 @pytest.fixture(scope='function')
 def nsproxy(request):
     ns = run_nameserver()

--- a/osbrain/tests/common.py
+++ b/osbrain/tests/common.py
@@ -6,7 +6,7 @@ from osbrain import run_nameserver
 from osbrain.helper import sync_agent_logger
 
 
-def receive(agent, message, topic=None):
+def append_received(agent, message, topic=None):
     agent.received.append(message)
 
 

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -22,7 +22,7 @@ from osbrain.helper import sync_agent_logger
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
-from common import receive
+from common import append_received
 from common import set_received
 
 
@@ -196,7 +196,7 @@ def test_linger(nsproxy, linger, sleep_time, should_receive):
     puller = run_agent('puller', base=AgentTest)
     pusher = run_agent('pusher', base=AgentTest)
 
-    address = puller.bind('PULL', alias='pull', handler=receive,
+    address = puller.bind('PULL', alias='pull', handler=append_received,
                           transport='tcp')
 
     pusher.connect(address, alias='push')
@@ -210,8 +210,8 @@ def test_linger(nsproxy, linger, sleep_time, should_receive):
     time.sleep(sleep_time)
 
     puller = run_agent('puller', base=AgentTest)
-    puller.bind('PULL', alias='pull', handler=receive, addr=address.address,
-                transport='tcp')
+    puller.bind('PULL', alias='pull', handler=append_received,
+                addr=address.address, transport='tcp')
 
     assert should_receive == wait_agent_attr(puller, data='foo', timeout=.2)
 

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -22,14 +22,11 @@ from osbrain.helper import sync_agent_logger
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
+from common import receive
 
 
 def set_received(agent, message, topic=None):
     agent.received = message
-
-
-def receive(agent, message):
-    agent.received.append(message)
 
 
 def test_agent_uuid():

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -23,10 +23,7 @@ from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
 from common import receive
-
-
-def set_received(agent, message, topic=None):
-    agent.received = message
+from common import set_received
 
 
 def test_agent_uuid():

--- a/osbrain/tests/test_agent_async_requests.py
+++ b/osbrain/tests/test_agent_async_requests.py
@@ -4,6 +4,7 @@ Test file for asynchronous requests.
 import time
 
 from osbrain import run_agent
+from osbrain import Agent
 from osbrain import run_logger
 from osbrain.helper import sync_agent_logger
 from osbrain.helper import logger_received
@@ -19,6 +20,16 @@ def on_error(agent):
     agent.error_count += 1
 
 
+class Server(Agent):
+    def on_init(self):
+        self.received = []
+
+
+class Client(Agent):
+    def on_init(self):
+        self.received = []
+
+
 def test_return(nsproxy):
     """
     Asynchronous request-reply pattern with a reply handler that returns.
@@ -28,10 +39,8 @@ def test_return(nsproxy):
         time.sleep(1)
         return 'x' + request
 
-    server = run_agent('server')
-    client = run_agent('client')
-    server.set_attr(received=[])
-    client.set_attr(received=[])
+    server = run_agent('server', base=Server)
+    client = run_agent('client', base=Client)
 
     addr = server.bind('ASYNC_REP', alias='replier', handler=late_reply)
     client.connect(addr, alias='async', handler=receive)
@@ -66,10 +75,8 @@ def test_yield(nsproxy):
         yield 'x' + request
         agent.received.append('y' + request)
 
-    server = run_agent('server')
-    client = run_agent('client')
-    server.set_attr(received=[])
-    client.set_attr(received=[])
+    server = run_agent('server', base=Server)
+    client = run_agent('client', base=Client)
 
     addr = server.bind('ASYNC_REP', alias='replier', handler=late_reply)
     client.connect(addr, alias='async', handler=receive)
@@ -104,11 +111,9 @@ def test_unknown(nsproxy):
         time.sleep(1)
         return 'x' + request
 
-    server = run_agent('server')
-    client = run_agent('client')
+    server = run_agent('server', base=Server)
+    client = run_agent('client', base=Client)
     logger = run_logger('logger')
-    server.set_attr(received=[])
-    client.set_attr(received=[])
     client.set_logger(logger)
     sync_agent_logger(client, logger)
 
@@ -135,11 +140,9 @@ def test_wait(nsproxy):
         time.sleep(delay)
         return 'x' + str(delay)
 
-    server = run_agent('server')
-    client = run_agent('client')
+    server = run_agent('server', base=Server)
+    client = run_agent('client', base=Client)
     logger = run_logger('logger')
-    server.set_attr(received=[])
-    client.set_attr(received=[])
     client.set_logger(logger)
     sync_agent_logger(client, logger)
 
@@ -171,10 +174,8 @@ def test_wait_on_error(nsproxy):
         time.sleep(delay)
         return 'x' + str(delay)
 
-    server = run_agent('server')
-    client = run_agent('client')
-    server.set_attr(received=[])
-    client.set_attr(received=[])
+    server = run_agent('server', base=Server)
+    client = run_agent('client', base=Client)
     client.set_attr(error_count=0)
 
     addr = server.bind('ASYNC_REP', alias='replier', handler=late_reply)

--- a/osbrain/tests/test_agent_async_requests.py
+++ b/osbrain/tests/test_agent_async_requests.py
@@ -11,6 +11,10 @@ from osbrain.helper import logger_received
 from common import nsproxy  # pragma: no flakes
 
 
+def receive(agent, response):
+    agent.received.append(response)
+
+
 def on_error(agent):
     agent.error_count += 1
 
@@ -23,9 +27,6 @@ def test_return(nsproxy):
         agent.received.append(request)
         time.sleep(1)
         return 'x' + request
-
-    def receive(agent, response):
-        agent.received.append(response)
 
     server = run_agent('server')
     client = run_agent('client')
@@ -65,9 +66,6 @@ def test_yield(nsproxy):
         yield 'x' + request
         agent.received.append('y' + request)
 
-    def receive(agent, response):
-        agent.received.append(response)
-
     server = run_agent('server')
     client = run_agent('client')
     server.set_attr(received=[])
@@ -106,9 +104,6 @@ def test_unknown(nsproxy):
         time.sleep(1)
         return 'x' + request
 
-    def receive(agent, response):
-        agent.received.append(response)
-
     server = run_agent('server')
     client = run_agent('client')
     logger = run_logger('logger')
@@ -139,9 +134,6 @@ def test_wait(nsproxy):
         agent.received.append(delay)
         time.sleep(delay)
         return 'x' + str(delay)
-
-    def receive(agent, response):
-        agent.received.append(response)
 
     server = run_agent('server')
     client = run_agent('client')
@@ -178,9 +170,6 @@ def test_wait_on_error(nsproxy):
         agent.received.append(delay)
         time.sleep(delay)
         return 'x' + str(delay)
-
-    def receive(agent, response):
-        agent.received.append(response)
 
     server = run_agent('server')
     client = run_agent('client')

--- a/osbrain/tests/test_agent_async_requests.py
+++ b/osbrain/tests/test_agent_async_requests.py
@@ -12,7 +12,7 @@ from osbrain.helper import sync_agent_logger
 from osbrain.helper import logger_received
 
 from common import nsproxy  # pragma: no flakes
-from common import receive
+from common import append_received
 
 
 def on_error(agent):
@@ -40,7 +40,7 @@ def server_client_late_reply_return():
     client = run_agent('client', base=Client)
 
     addr = server.bind('ASYNC_REP', alias='replier', handler=late_reply)
-    client.connect(addr, alias='async', handler=receive)
+    client.connect(addr, alias='async', handler=append_received)
 
     return (server, client)
 
@@ -56,7 +56,7 @@ def server_client_late_reply_delay():
     client = run_agent('client', base=Client)
 
     addr = server.bind('ASYNC_REP', alias='replier', handler=late_reply)
-    client.connect(addr, alias='async', handler=receive)
+    client.connect(addr, alias='async', handler=append_received)
 
     return (server, client)
 
@@ -102,7 +102,7 @@ def test_yield(nsproxy):
     client = run_agent('client', base=Client)
 
     addr = server.bind('ASYNC_REP', alias='replier', handler=late_reply)
-    client.connect(addr, alias='async', handler=receive)
+    client.connect(addr, alias='async', handler=append_received)
 
     # Client requests should be non-blocking
     t0 = time.time()

--- a/osbrain/tests/test_agent_async_requests.py
+++ b/osbrain/tests/test_agent_async_requests.py
@@ -12,10 +12,7 @@ from osbrain.helper import sync_agent_logger
 from osbrain.helper import logger_received
 
 from common import nsproxy  # pragma: no flakes
-
-
-def receive(agent, response):
-    agent.received.append(response)
+from common import receive
 
 
 def on_error(agent):

--- a/osbrain/tests/test_agent_async_requests_handlers.py
+++ b/osbrain/tests/test_agent_async_requests_handlers.py
@@ -8,6 +8,7 @@ from osbrain import run_agent
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
+from common import receive
 
 
 class Server_ASYNC_REP(Agent):
@@ -31,10 +32,6 @@ class ClientWithHandler(Agent):
         self.received.append(response)
 
 
-def receive_function(agent, response):
-    agent.received.append(response)
-
-
 def test_async_rep_handler_exists(nsproxy):
     '''
     When binding an ASYNC_REP socket without a handler, an exception must be
@@ -49,7 +46,7 @@ def test_async_rep_handler_exists(nsproxy):
 
 @pytest.mark.parametrize(
     'handler',
-    ['reply', receive_function, lambda a, x: a.received.append(x)]
+    ['reply', receive, lambda a, x: a.received.append(x)]
 )
 def test_async_rep_handler_types(nsproxy, handler):
     '''
@@ -65,7 +62,7 @@ def test_async_rep_handler_types(nsproxy, handler):
 @pytest.mark.parametrize(
     'handler, check_function',
     [('receive_method', False),
-     (receive_function, True),
+     (receive, True),
      (lambda a, x: a.received.append(x), False)])
 def test_async_rep_connect_handler_types(nsproxy, handler, check_function):
     '''
@@ -88,14 +85,14 @@ def test_async_rep_connect_handler_types(nsproxy, handler, check_function):
     if check_function:
         # Check that the function was not stored as a method for the object
         with pytest.raises(AttributeError) as error:
-            assert client.get_attr('receive_function')
+            assert client.get_attr('receive')
         assert 'object has no attribute' in str(error.value)
 
 
 @pytest.mark.parametrize(
     'handler, check_function',
     [('receive_method', False),
-     (receive_function, True),
+     (receive, True),
      (lambda a, x: a.received.append(x), False)])
 def test_async_rep_send_handler_types(nsproxy, handler, check_function):
     '''
@@ -116,5 +113,5 @@ def test_async_rep_send_handler_types(nsproxy, handler, check_function):
     if check_function:
         # Check that the function was not stored as a method for the object
         with pytest.raises(AttributeError) as error:
-            assert client.get_attr('receive_function')
+            assert client.get_attr('receive')
         assert 'object has no attribute' in str(error.value)

--- a/osbrain/tests/test_agent_async_requests_handlers.py
+++ b/osbrain/tests/test_agent_async_requests_handlers.py
@@ -8,7 +8,7 @@ from osbrain import run_agent
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
-from common import receive
+from common import append_received
 
 
 class Server_ASYNC_REP(Agent):
@@ -46,7 +46,7 @@ def test_async_rep_handler_exists(nsproxy):
 
 @pytest.mark.parametrize(
     'handler',
-    ['reply', receive, lambda a, x: a.received.append(x)]
+    ['reply', append_received, lambda a, x: a.received.append(x)]
 )
 def test_async_rep_handler_types(nsproxy, handler):
     '''
@@ -62,7 +62,7 @@ def test_async_rep_handler_types(nsproxy, handler):
 @pytest.mark.parametrize(
     'handler, check_function',
     [('receive_method', False),
-     (receive, True),
+     (append_received, True),
      (lambda a, x: a.received.append(x), False)])
 def test_async_rep_connect_handler_types(nsproxy, handler, check_function):
     '''
@@ -85,14 +85,14 @@ def test_async_rep_connect_handler_types(nsproxy, handler, check_function):
     if check_function:
         # Check that the function was not stored as a method for the object
         with pytest.raises(AttributeError) as error:
-            assert client.get_attr('receive')
+            assert client.get_attr('append_received')
         assert 'object has no attribute' in str(error.value)
 
 
 @pytest.mark.parametrize(
     'handler, check_function',
     [('receive_method', False),
-     (receive, True),
+     (append_received, True),
      (lambda a, x: a.received.append(x), False)])
 def test_async_rep_send_handler_types(nsproxy, handler, check_function):
     '''
@@ -113,5 +113,5 @@ def test_async_rep_send_handler_types(nsproxy, handler, check_function):
     if check_function:
         # Check that the function was not stored as a method for the object
         with pytest.raises(AttributeError) as error:
-            assert client.get_attr('receive')
+            assert client.get_attr('append_received')
         assert 'object has no attribute' in str(error.value)

--- a/osbrain/tests/test_agent_pubsub_topics.py
+++ b/osbrain/tests/test_agent_pubsub_topics.py
@@ -8,8 +8,8 @@ from osbrain.address import AgentAddressSerializer
 from common import nsproxy  # pragma: no flakes
 
 
-def log_received_to_list(agent, message, topic=None):
-    agent.received_list.append(message)
+def receive(agent, message, topic=None):
+    agent.received.append(message)
 
 
 @pytest.mark.parametrize(
@@ -32,16 +32,16 @@ def test_pubsub_topics_separator(nsproxy, serializer):
     a5 = run_agent('a5')
 
     for agent in (a1, a2, a3, a4, a5):
-        agent.set_attr(received_list=[])
+        agent.set_attr(received=[])
 
     addr = a0.bind('PUB', alias='pub', serializer=serializer)
 
-    a1.connect(addr, handler=log_received_to_list)
-    a2.connect(addr, handler={'foo': log_received_to_list})
-    a3.connect(addr, handler={'bar': log_received_to_list,
-                              'foo': log_received_to_list})
-    a4.connect(addr, handler={'bar': log_received_to_list})
-    a5.connect(addr, handler={'fo': log_received_to_list})
+    a1.connect(addr, handler=receive)
+    a2.connect(addr, handler={'foo': receive})
+    a3.connect(addr, handler={'bar': receive,
+                              'foo': receive})
+    a4.connect(addr, handler={'bar': receive})
+    a5.connect(addr, handler={'fo': receive})
 
     # Give some time for all the agents to connect
     time.sleep(0.1)
@@ -63,30 +63,30 @@ def test_pubsub_topics_separator(nsproxy, serializer):
     time.sleep(0.1)
 
     # Check each agent received the corresponding messages
-    assert message_01 in a1.get_attr('received_list')
-    assert message_02 in a1.get_attr('received_list')
-    assert message_03 in a1.get_attr('received_list')
-    assert message_04 in a1.get_attr('received_list')
+    assert message_01 in a1.get_attr('received')
+    assert message_02 in a1.get_attr('received')
+    assert message_03 in a1.get_attr('received')
+    assert message_04 in a1.get_attr('received')
 
-    assert message_01 not in a2.get_attr('received_list')
-    assert message_02 in a2.get_attr('received_list')
-    assert message_03 in a2.get_attr('received_list')
-    assert message_04 not in a2.get_attr('received_list')
+    assert message_01 not in a2.get_attr('received')
+    assert message_02 in a2.get_attr('received')
+    assert message_03 in a2.get_attr('received')
+    assert message_04 not in a2.get_attr('received')
 
-    assert message_01 not in a3.get_attr('received_list')
-    assert message_02 in a3.get_attr('received_list')
-    assert message_03 in a3.get_attr('received_list')
-    assert message_04 not in a3.get_attr('received_list')
+    assert message_01 not in a3.get_attr('received')
+    assert message_02 in a3.get_attr('received')
+    assert message_03 in a3.get_attr('received')
+    assert message_04 not in a3.get_attr('received')
 
-    assert message_01 not in a4.get_attr('received_list')
-    assert message_02 not in a4.get_attr('received_list')
-    assert message_03 not in a4.get_attr('received_list')
-    assert message_04 not in a4.get_attr('received_list')
+    assert message_01 not in a4.get_attr('received')
+    assert message_02 not in a4.get_attr('received')
+    assert message_03 not in a4.get_attr('received')
+    assert message_04 not in a4.get_attr('received')
 
-    assert message_01 not in a5.get_attr('received_list')
-    assert message_02 in a5.get_attr('received_list')
-    assert message_03 in a5.get_attr('received_list')
-    assert message_04 in a5.get_attr('received_list')
+    assert message_01 not in a5.get_attr('received')
+    assert message_02 in a5.get_attr('received')
+    assert message_03 in a5.get_attr('received')
+    assert message_04 in a5.get_attr('received')
 
 
 @pytest.mark.parametrize(
@@ -112,16 +112,16 @@ def test_pubsub_topics_raw(nsproxy, serializer):
     a5 = run_agent('a5')
 
     for agent in (a1, a2, a3, a4, a5):
-        agent.set_attr(received_list=[])
+        agent.set_attr(received=[])
 
     addr = a0.bind('PUB', alias='pub', serializer=serializer)
 
-    a1.connect(addr, handler=log_received_to_list)
-    a2.connect(addr, handler={'foo': log_received_to_list})
-    a3.connect(addr, handler={'bar': log_received_to_list,
-                              'foo': log_received_to_list})
-    a4.connect(addr, handler={'bar': log_received_to_list})
-    a5.connect(addr, handler={'fo': log_received_to_list})
+    a1.connect(addr, handler=receive)
+    a2.connect(addr, handler={'foo': receive})
+    a3.connect(addr, handler={'bar': receive,
+                              'foo': receive})
+    a4.connect(addr, handler={'bar': receive})
+    a5.connect(addr, handler={'fo': receive})
 
     # Give some time for all the agents to connect
     time.sleep(0.1)
@@ -143,27 +143,27 @@ def test_pubsub_topics_raw(nsproxy, serializer):
     time.sleep(0.1)
 
     # Check each agent received the corresponding messages
-    assert message_01 in a1.get_attr('received_list')
-    assert b'fooWorld' in a1.get_attr('received_list')
-    assert b'foobarFOO' in a1.get_attr('received_list')
-    assert b'foBAR' in a1.get_attr('received_list')
+    assert message_01 in a1.get_attr('received')
+    assert b'fooWorld' in a1.get_attr('received')
+    assert b'foobarFOO' in a1.get_attr('received')
+    assert b'foBAR' in a1.get_attr('received')
 
-    assert message_01 not in a2.get_attr('received_list')
-    assert b'fooWorld' in a2.get_attr('received_list')
-    assert b'foobarFOO' in a2.get_attr('received_list')
-    assert b'foBAR' not in a2.get_attr('received_list')
+    assert message_01 not in a2.get_attr('received')
+    assert b'fooWorld' in a2.get_attr('received')
+    assert b'foobarFOO' in a2.get_attr('received')
+    assert b'foBAR' not in a2.get_attr('received')
 
-    assert message_01 not in a3.get_attr('received_list')
-    assert b'fooWorld' in a3.get_attr('received_list')
-    assert b'foobarFOO' in a3.get_attr('received_list')
-    assert b'foBAR' not in a3.get_attr('received_list')
+    assert message_01 not in a3.get_attr('received')
+    assert b'fooWorld' in a3.get_attr('received')
+    assert b'foobarFOO' in a3.get_attr('received')
+    assert b'foBAR' not in a3.get_attr('received')
 
-    assert message_01 not in a4.get_attr('received_list')
-    assert b'fooWorld' not in a4.get_attr('received_list')
-    assert b'foobarFOO' not in a4.get_attr('received_list')
-    assert b'foBAR' not in a4.get_attr('received_list')
+    assert message_01 not in a4.get_attr('received')
+    assert b'fooWorld' not in a4.get_attr('received')
+    assert b'foobarFOO' not in a4.get_attr('received')
+    assert b'foBAR' not in a4.get_attr('received')
 
-    assert message_01 not in a5.get_attr('received_list')
-    assert b'fooWorld' in a5.get_attr('received_list')
-    assert b'foobarFOO' in a5.get_attr('received_list')
-    assert b'foBAR' in a5.get_attr('received_list')
+    assert message_01 not in a5.get_attr('received')
+    assert b'fooWorld' in a5.get_attr('received')
+    assert b'foobarFOO' in a5.get_attr('received')
+    assert b'foBAR' in a5.get_attr('received')

--- a/osbrain/tests/test_agent_pubsub_topics.py
+++ b/osbrain/tests/test_agent_pubsub_topics.py
@@ -6,7 +6,7 @@ from osbrain import run_agent
 from osbrain.address import AgentAddressSerializer
 
 from common import nsproxy  # pragma: no flakes
-from common import receive
+from common import append_received
 
 
 @pytest.mark.parametrize(
@@ -33,12 +33,12 @@ def test_pubsub_topics_separator(nsproxy, serializer):
 
     addr = a0.bind('PUB', alias='pub', serializer=serializer)
 
-    a1.connect(addr, handler=receive)
-    a2.connect(addr, handler={'foo': receive})
-    a3.connect(addr, handler={'bar': receive,
-                              'foo': receive})
-    a4.connect(addr, handler={'bar': receive})
-    a5.connect(addr, handler={'fo': receive})
+    a1.connect(addr, handler=append_received)
+    a2.connect(addr, handler={'foo': append_received})
+    a3.connect(addr, handler={'bar': append_received,
+                              'foo': append_received})
+    a4.connect(addr, handler={'bar': append_received})
+    a5.connect(addr, handler={'fo': append_received})
 
     # Give some time for all the agents to connect
     time.sleep(0.1)
@@ -113,12 +113,12 @@ def test_pubsub_topics_raw(nsproxy, serializer):
 
     addr = a0.bind('PUB', alias='pub', serializer=serializer)
 
-    a1.connect(addr, handler=receive)
-    a2.connect(addr, handler={'foo': receive})
-    a3.connect(addr, handler={'bar': receive,
-                              'foo': receive})
-    a4.connect(addr, handler={'bar': receive})
-    a5.connect(addr, handler={'fo': receive})
+    a1.connect(addr, handler=append_received)
+    a2.connect(addr, handler={'foo': append_received})
+    a3.connect(addr, handler={'bar': append_received,
+                              'foo': append_received})
+    a4.connect(addr, handler={'bar': append_received})
+    a5.connect(addr, handler={'fo': append_received})
 
     # Give some time for all the agents to connect
     time.sleep(0.1)

--- a/osbrain/tests/test_agent_pubsub_topics.py
+++ b/osbrain/tests/test_agent_pubsub_topics.py
@@ -6,10 +6,7 @@ from osbrain import run_agent
 from osbrain.address import AgentAddressSerializer
 
 from common import nsproxy  # pragma: no flakes
-
-
-def receive(agent, message, topic=None):
-    agent.received.append(message)
+from common import receive
 
 
 @pytest.mark.parametrize(

--- a/osbrain/tests/test_agent_serialization.py
+++ b/osbrain/tests/test_agent_serialization.py
@@ -15,10 +15,7 @@ from osbrain.address import AgentAddressSerializer
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
-
-
-def set_received(agent, message, topic=None):
-    agent.received = message
+from common import set_received
 
 
 def test_compose_message():

--- a/osbrain/tests/test_agent_sync_publications.py
+++ b/osbrain/tests/test_agent_sync_publications.py
@@ -13,6 +13,7 @@ from osbrain.helper import logger_received
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
+from common import receive
 
 
 class BaseServer(Agent):
@@ -62,10 +63,6 @@ class Client(Agent):
     def on_init(self):
         self.received = []
         self.error_log = []
-
-
-def receive(agent, response):
-    agent.received.append(response)
 
 
 def receive_negate(agent, response):

--- a/osbrain/tests/test_agent_sync_publications_handlers.py
+++ b/osbrain/tests/test_agent_sync_publications_handlers.py
@@ -8,6 +8,7 @@ from osbrain import run_agent
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
+from common import receive
 
 
 class Server_SYNC_PUB(Agent):
@@ -35,10 +36,6 @@ class ClientWithHandler(Agent):
         self.alternative_received.append(response)
 
 
-def receive_function(agent, response):
-    agent.received.append(response)
-
-
 def test_sync_pub_handler_exists(nsproxy):
     '''
     When binding a SYNC_PUB socket without a handler, an exception must be
@@ -53,7 +50,7 @@ def test_sync_pub_handler_exists(nsproxy):
 
 @pytest.mark.parametrize(
     'handler',
-    ['reply', receive_function, lambda a, x: a.received.append(x)]
+    ['reply', receive, lambda a, x: a.received.append(x)]
 )
 def test_sync_pub_handler_types(nsproxy, handler):
     '''
@@ -69,7 +66,7 @@ def test_sync_pub_handler_types(nsproxy, handler):
 @pytest.mark.parametrize(
     'handler, check_function',
     [('receive_method', False),
-     (receive_function, True),
+     (receive, True),
      (lambda a, x: a.received.append(x), False)])
 def test_sync_pub_connect_handler_types(nsproxy, handler, check_function):
     '''
@@ -91,14 +88,14 @@ def test_sync_pub_connect_handler_types(nsproxy, handler, check_function):
     if check_function:
         # Check that the function was not stored as a method for the object
         with pytest.raises(AttributeError) as error:
-            assert client.get_attr('receive_function')
+            assert client.get_attr('receive')
         assert 'object has no attribute' in str(error.value)
 
 
 @pytest.mark.parametrize(
     'handler, check_function, should_crash',
     [('receive_method', False, False),
-     (receive_function, True, False),
+     (receive, True, False),
      (lambda a, x: a.received.append(x), False, False),
      (None, False, True)])
 def test_sync_pub_send_handlers(nsproxy, handler, check_function,
@@ -128,5 +125,5 @@ def test_sync_pub_send_handlers(nsproxy, handler, check_function,
         if check_function:
             # Check that the function was not stored as a method for the object
             with pytest.raises(AttributeError) as error:
-                assert client.get_attr('receive_function')
+                assert client.get_attr('receive')
             assert 'object has no attribute' in str(error.value)

--- a/osbrain/tests/test_agent_sync_publications_handlers.py
+++ b/osbrain/tests/test_agent_sync_publications_handlers.py
@@ -8,7 +8,7 @@ from osbrain import run_agent
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
-from common import receive
+from common import append_received
 
 
 class Server_SYNC_PUB(Agent):
@@ -50,7 +50,7 @@ def test_sync_pub_handler_exists(nsproxy):
 
 @pytest.mark.parametrize(
     'handler',
-    ['reply', receive, lambda a, x: a.received.append(x)]
+    ['reply', append_received, lambda a, x: a.received.append(x)]
 )
 def test_sync_pub_handler_types(nsproxy, handler):
     '''
@@ -66,7 +66,7 @@ def test_sync_pub_handler_types(nsproxy, handler):
 @pytest.mark.parametrize(
     'handler, check_function',
     [('receive_method', False),
-     (receive, True),
+     (append_received, True),
      (lambda a, x: a.received.append(x), False)])
 def test_sync_pub_connect_handler_types(nsproxy, handler, check_function):
     '''
@@ -88,14 +88,14 @@ def test_sync_pub_connect_handler_types(nsproxy, handler, check_function):
     if check_function:
         # Check that the function was not stored as a method for the object
         with pytest.raises(AttributeError) as error:
-            assert client.get_attr('receive')
+            assert client.get_attr('append_received')
         assert 'object has no attribute' in str(error.value)
 
 
 @pytest.mark.parametrize(
     'handler, check_function, should_crash',
     [('receive_method', False, False),
-     (receive, True, False),
+     (append_received, True, False),
      (lambda a, x: a.received.append(x), False, False),
      (None, False, True)])
 def test_sync_pub_send_handlers(nsproxy, handler, check_function,
@@ -125,5 +125,5 @@ def test_sync_pub_send_handlers(nsproxy, handler, check_function,
         if check_function:
             # Check that the function was not stored as a method for the object
             with pytest.raises(AttributeError) as error:
-                assert client.get_attr('receive')
+                assert client.get_attr('append_received')
             assert 'object has no attribute' in str(error.value)

--- a/osbrain/tests/test_agent_transport.py
+++ b/osbrain/tests/test_agent_transport.py
@@ -14,6 +14,7 @@ from osbrain import SocketAddress
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
+from common import receive
 
 
 def test_agent_bind_transport_global(nsproxy):
@@ -96,9 +97,6 @@ def test_agent_ipc_from_different_folders(nsproxy):
     class Wdagent(Agent):
         def on_init(self):
             self.received = []
-
-    def receive(agent, message):
-        agent.received.append(message)
 
     dira = mkdtemp()
     dirb = mkdtemp()

--- a/osbrain/tests/test_agent_transport.py
+++ b/osbrain/tests/test_agent_transport.py
@@ -14,7 +14,7 @@ from osbrain import SocketAddress
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
-from common import receive
+from common import append_received
 
 
 def test_agent_bind_transport_global(nsproxy):
@@ -105,8 +105,9 @@ def test_agent_ipc_from_different_folders(nsproxy):
     # First agent run for directory `a`
     os.chdir(dira)
     a = run_agent('a', base=Wdagent)
-    random_addr = a.bind('PULL', transport='ipc', handler=receive)
-    set_addr = a.bind('PULL', addr='qwer', transport='ipc', handler=receive)
+    random_addr = a.bind('PULL', transport='ipc', handler=append_received)
+    set_addr = a.bind('PULL', addr='qwer', transport='ipc',
+                      handler=append_received)
 
     # Second agent run for directory `b`
     os.chdir(dirb)

--- a/osbrain/tests/test_helper.py
+++ b/osbrain/tests/test_helper.py
@@ -125,7 +125,7 @@ def test_wait_agent_attr(nsproxy):
     Test `wait_agent_attr` function.
     """
     class Client(Agent):
-        def set_received(self, value):
+        def set_received_method(self, value):
             self.received = value
 
     a0 = run_agent('a0', base=Client)
@@ -136,6 +136,6 @@ def test_wait_agent_attr(nsproxy):
 
     # Default attribute, timeout
     a0.set_attr(received=0)
-    a0.after(1, 'set_received', 42)
+    a0.after(1, 'set_received_method', 42)
     assert not wait_agent_attr(a0, value=42, timeout=0.)
     assert wait_agent_attr(a0, value=42, timeout=2.)

--- a/osbrain/tests/test_proxy.py
+++ b/osbrain/tests/test_proxy.py
@@ -15,7 +15,7 @@ from osbrain.proxy import locate_ns
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
-from common import receive
+from common import append_received
 
 
 def since(t0, passed, tolerance):
@@ -301,7 +301,7 @@ def test_agent_proxy_oneway(nsproxy):
     """
     class OneWayne(Agent):
         def on_init(self):
-            target = self.bind('PULL', alias='target', handler=receive,
+            target = self.bind('PULL', alias='target', handler=append_received,
                                transport='inproc')
             self.target = target
             self.received = []

--- a/osbrain/tests/test_proxy.py
+++ b/osbrain/tests/test_proxy.py
@@ -15,6 +15,7 @@ from osbrain.proxy import locate_ns
 from osbrain.helper import wait_agent_attr
 
 from common import nsproxy  # pragma: no flakes
+from common import receive
 
 
 def since(t0, passed, tolerance):
@@ -300,7 +301,7 @@ def test_agent_proxy_oneway(nsproxy):
     """
     class OneWayne(Agent):
         def on_init(self):
-            target = self.bind('PULL', alias='target', handler=self.receive,
+            target = self.bind('PULL', alias='target', handler=receive,
                                transport='inproc')
             self.target = target
             self.received = []
@@ -310,9 +311,6 @@ def test_agent_proxy_oneway(nsproxy):
             for i in range(10):
                 self.send('gun', 'bang!')
                 time.sleep(0.1)
-
-        def receive(self, message):
-            self.received.append(message)
 
     wayne = run_agent('wayne', base=OneWayne)
 

--- a/osbrain/tests/test_timer.py
+++ b/osbrain/tests/test_timer.py
@@ -8,10 +8,7 @@ from osbrain import run_agent
 from osbrain.common import repeat
 
 from common import nsproxy  # pragma: no flakes
-
-
-def set_received(agent, message, topic=None):
-    agent.received = message
+from common import set_received
 
 
 @pytest.mark.timeout(1)


### PR DESCRIPTION
A bit of test refactoring. No test functionality should have been modified. Main improvements:
- Reuse the same `receive` function, instead of having it declared in multiple files.
- Refactorization of `test_agent_async_requests` through fixtures.
- Add more consistency in the naming of the tests (`agent.received`, `handler=receive`...)