### PR TITLE
Remove duplicate distributed systems in index docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,7 +39,6 @@ Contents
    complex_patterns.rst
    timers.rst
    transport_protocol.rst
-   distributed_systems.rst
    serialization.rst
    advanced_proxy_handling.rst
    distributed_systems.rst


### PR DESCRIPTION
Fail...

Apparently, there was already an entry in the index for distributed systems (although the documentation was actually missing...). :sweat_smile: 