### PR TITLE
Allow attributes to be set when running an agent

### DIFF
--- a/docs/source/considerations.rst
+++ b/docs/source/considerations.rst
@@ -108,3 +108,27 @@ however you may notice some differences:
    to. As the binding was executed on initialization, we need to use the
    ``addr()`` method, which will return the address associated to the alias
    passed as parameter (in the example above it is ``main``).
+
+
+Setting initial attributes
+==========================
+
+Many times, after spawning an agent, we want to set some attributes, which
+may be used to configure the agent before it starts working with the rest of
+the multi-agent system:
+
+.. code-block:: python
+
+   a0 = run_agent('foo')
+   a0.set_attr(x=1, y=2)
+
+It is such a common task that a parameter ``attributes`` can be used when
+running the agent for exactly that:
+
+.. code-block:: python
+
+   a0 = run_agent('foo', attributes=dict(x=1, y=2))
+
+As you can see, this parameter accepts a dictionary in which the keys are the
+name of the attributes to be set in the agent and the values are the actual
+values that this attributes will take.

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -102,6 +102,28 @@ def test_agent_shutdown(nsproxy):
     assert 'a0' not in nsproxy.list()
 
 
+def test_run_agent_initial_attributes(nsproxy):
+    """
+    The user can specify a set of attributes to be set in the agent when
+    creating it.
+    """
+    a0 = run_agent('a0', attributes=dict(x=1, y='a'))
+    assert a0.get_attr('x') == 1
+    assert a0.get_attr('y') == 'a'
+
+
+def test_run_agent_initial_attributes_exception(nsproxy):
+    """
+    The user can specify a set of attributes to be set in the agent when
+    creating it. If the attribute specified overrites an existing attribute,
+    an exception will be raised.
+    """
+    with pytest.raises(RuntimeError) as error:
+        run_agent('a0', attributes=dict(name='foo'))
+    assert 'KeyError' in str(error.value)
+    assert 'Agent already has "name" attribute!' in str(error.value)
+
+
 def test_set_method(nsproxy):
     """
     Set new methods for the agent.


### PR DESCRIPTION
It is a common task, so this makes it easier for the end user.

In our walk-forward analysis system it also allows to take advantage of the COW on Unix systems and reduce memory usage (we set big read-only market data history dataframes from the parent process using this new parameter and we avoid complete copies on each backtest worker).