### PR TITLE
Use `logger_received()` to avoid uncovered sleeps

### DIFF
--- a/osbrain/tests/test_logging.py
+++ b/osbrain/tests/test_logging.py
@@ -2,11 +2,11 @@
 Logging module tests.
 """
 import os
-import time
 
 from osbrain import run_agent
 from osbrain import run_logger
 from osbrain.logging import pyro_log
+from osbrain.helper import logger_received
 
 from common import nsproxy  # pragma: no flakes
 
@@ -24,26 +24,22 @@ def test_logging_level(nsproxy):
     while not len(logger.get_attr('log_history')):
         i += 1
         agent.log_info(i)
-    while not '): %s' % i in logger.get_attr('log_history')[-1]:
-        time.sleep(0.01)
+    assert logger_received(logger, message='\): %s' % i, position=-1)
     before = len(logger.get_attr('log_history'))
     agent.log_info('some information')
     agent.log_warning('some warning')
     agent.log_error('some error')
     agent.log_debug('some debug')
-    after = before
-    while not after - before == 4:
-        after = len(logger.get_attr('log_history'))
-    # Log size
+    # Log values
+    assert logger_received(logger, 'some information', 'log_history_info', -1)
+    assert logger_received(logger, 'some warning', 'log_history_warning', -1)
+    assert logger_received(logger, 'some error', 'log_history_error', -1)
+    assert logger_received(logger, 'some debug', 'log_history_debug', -1)
+    # Log sizes
     assert len(logger.get_attr('log_history_info')) == 1 + before
     assert len(logger.get_attr('log_history_warning')) == 1
     assert len(logger.get_attr('log_history_error')) == 1
     assert len(logger.get_attr('log_history_debug')) == 1
-    # Log message
-    assert 'some information' in logger.get_attr('log_history_info')[-1]
-    assert 'some warning' in logger.get_attr('log_history_warning')[-1]
-    assert 'some error' in logger.get_attr('log_history_error')[-1]
-    assert 'some debug' in logger.get_attr('log_history_debug')[-1]
 
 
 def test_pyro_log():

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         'Pyro4>=4.48',
         'pyzmq>=15.2.0',
-        'dill>=0.2.0',
+        'dill>=0.2.0,!=0.2.7',
     ] + install_requires_compat,
     extras_require={
         'dev': [],


### PR DESCRIPTION
Should avoid this coverage regression:

https://codecov.io/gh/opensistemas-hub/osbrain/pull/160/src/osbrain/tests/test_logging.py