### PR TITLE
Make shutdown process a bit more reliable

### DIFF
--- a/osbrain/proxy.py
+++ b/osbrain/proxy.py
@@ -327,12 +327,12 @@ class NSProxy(Pyro4.core.Proxy):
         timeout : float, default is 10.
             Timeout, in seconds, to wait for the agents to shutdown.
         """
-        super()._pyroInvoke('async_shutdown_agents', (self.addr(), ), {})
         # Wait for all agents to be shutdown (unregistered)
         time0 = time.time()
         while True:
             if not len(self.agents()):
                 break
+            super()._pyroInvoke('async_shutdown_agents', (self.addr(), ), {})
             time.sleep(0.1)
             if time.time() - time0 >= timeout:
                 raise TimeoutError(


### PR DESCRIPTION
Maybe fixes_ #182.

For now 25/27 runs passed (considering a run to be one of the three jobs Travis executes for each Python version).

The 2 only errors are due to `test_nameserver_proxy_shutdown_with_many_agents()` failing. Will investigate that failure separately. No other failures found.

I still consider this to be far more reliable than the current process. Also, the error is now at least displayed in the Travis log (before we used to get a stall but no errors, which is much worse).