### PR TITLE
Rename `.configure()` method to `.before_run()`

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -55,11 +55,16 @@ saying `Hello world!` but, what exactly is happening there?
 Agents and proxies
 ==================
 
-An agent, in osBrain, is an entity that runs independly from other agents
-in the system. An agent, by default, will simply poll for incoming messages
-before executing the code defined by the developer. This means a single agent,
-as in the `Hello world!` example, makes little or no sense. Agents in a
-multi-agent system start to make sense when connected to each other.
+An agent, in osBrain, is an entity that runs independly from other agents in
+the system. When running, it executes the main loop:
+
+- Poll for incoming messages.
+- Process incoming messages and execute developer-defined code.
+- Repeat.
+
+This means a single agent, as in the `Hello world!` example, makes little or no
+sense. Agents in a multi-agent system start to make sense when connected to
+each other.
 
 The easiest way to run an agent in an osBrain architecture is by calling the
 function :func:`osbrain.run_agent <osbrain.agent.run_agent>`:

--- a/docs/source/timers.rst
+++ b/docs/source/timers.rst
@@ -18,9 +18,9 @@ Note that if an action takes longer to run than the time available before the
 next execution, the timer will simply fall behind.
 
 .. note:: To be able to start timers on agent initalization, the agent must be
-   already running, which means you cannot do it from ``on_init()``. Instead,
-   you can use ``configure()``, which will be executed when the agent is
-   already running, right before starting the main loop.
+   already running, which means you cannot do it from `.on_init()`. Instead,
+   you can use `.before_loop()`, which will be called inside the `.run()`
+   method and before starting the main loop.
 
 
 Delayed actions

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -288,7 +288,7 @@ class Agent():
         """
         pass
 
-    def configure(self):
+    def before_loop(self):
         """
         This user-defined method is to be executed right before the main loop.
         """
@@ -1640,7 +1640,7 @@ class Agent():
         Start the main loop.
         """
         self._running = True
-        self.configure()
+        self.before_loop()
         try:
             self._loop()
         except Exception as error:

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -103,15 +103,15 @@ def test_late_runner(nsproxy):
     assert a0.ping() == 'pong'
 
 
-def test_agent_configure(nsproxy):
+def test_agent_before_loop(nsproxy):
     """
-    Tests agent's `configure()` method, which should be able to start timers.
+    Tests agent's `before_loop()` method, which should be able to start timers.
     """
     class MyAgent(Agent):
         def on_init(self):
             self.x = 0
 
-        def configure(self):
+        def before_loop(self):
             self.each(.5, 'incr')
 
         def incr(self):


### PR DESCRIPTION
Fixes #243.

Note that I changed the documentation paragraph to avoid saying "before_run is executed when the agent is running", which can be counter-intuitive.

I was thinking we could simply end the paragraph with "Instead, you can use `before_run()`.". In example: we may not need to tell the user it is being executed right before the main loop.

@ocaballeror What do you think?