### PR TITLE
Fix resulting host when binding to a specific one

### DIFF
--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -812,19 +812,39 @@ class Agent():
             The address where the socket binded to.
         """
         if transport == 'tcp':
-            host, port = address_to_host_port(addr)
-            if not port:
-                uri = 'tcp://%s' % self._host
-                port = socket.bind_to_random_port(uri)
-                addr = self._host + ':' + str(port)
-            else:
-                socket.bind('tcp://%s' % (addr))
+            return self._bind_socket_tcp(socket, addr=addr)
+        if not addr:
+            addr = str(unique_identifier())
+        if transport == 'ipc':
+            addr = config['IPC_DIR'] / addr
+        socket.bind('%s://%s' % (transport, addr))
+        return addr
+
+    def _bind_socket_tcp(self, socket, addr):
+        """
+        Bind a socket using the TCP transport and corresponding address.
+
+        Parameters
+        ----------
+        socket : zmq.Socket
+            Socket to bind.
+        addr : str, default is None
+            The address to bind to.
+
+        Returns
+        -------
+        addr : str
+            The address where the socket binded to.
+        """
+        host, port = address_to_host_port(addr)
+        if not host:
+            host = self._host
+        if not port:
+            uri = 'tcp://%s' % host
+            port = socket.bind_to_random_port(uri)
+            addr = host + ':' + str(port)
         else:
-            if not addr:
-                addr = str(unique_identifier())
-            if transport == 'ipc':
-                addr = config['IPC_DIR'] / addr
-            socket.bind('%s://%s' % (transport, addr))
+            socket.bind('tcp://%s' % (addr))
         return addr
 
     def connect(self, server, alias=None, handler=None):

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -234,14 +234,14 @@ def test_socket_creation(nsproxy):
     assert a0.addr('alias2') == addr2
 
 
-def test_bind_tcp_addr_random_port(nsproxy):
+@pytest.mark.parametrize('host', ['127.0.0.1', '0.0.0.0'])
+def test_bind_tcp_addr_random_port(nsproxy, host):
     """
     When using TCP transport, the bind method allows the user to specify the
     network interface to bind to. When no port is specified, a random one will
     be used.
     """
     agent = run_agent('a0')
-    host = '127.0.0.1'
     address = agent.bind('PUB', transport='tcp', addr=host)
     assert isinstance(address.address, SocketAddress)
     assert address.address.host == host


### PR DESCRIPTION
Even if the user set a different host, the bind always used the agent's
default (i.e.: 127.0.0.1).

Fixes #246.