### PR TITLE
Spelling revision

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -53,7 +53,7 @@ Python was chosen for being a great language for fast prototyping and for
 having a huge data analysis ecosystem available. It was kept for its final
 performance and the beautiful source code created with it.
 
-The appearance of osBrain was a consecuence of a series of steps that were
+The appearance of osBrain was a consequence of a series of steps that were
 taken during the development process:
 
 #. **Isolation of agents**; creating separate system processes to avoid shared

--- a/docs/source/advanced_proxy_handling.rst
+++ b/docs/source/advanced_proxy_handling.rst
@@ -71,7 +71,7 @@ Or when creating a new :class:`Proxy <osbrain.proxy.Proxy>` to the agent:
 
    agent.method_call()  # This is now by default an unsafe method_call()
 
-.. note:: It is also possible, although totally unadvisable, to change the
+.. note:: It is also possible, although totally inadvisable, to change the
    default proxy behavior globally. Setting the ``OSBRAIN_DEFAULT_SAFE``
    environment variable to ``false`` would result in all proxies making unsafe
    calls by default. Another option is to change the ``osbrain.config['SAFE']``

--- a/docs/source/considerations.rst
+++ b/docs/source/considerations.rst
@@ -127,7 +127,7 @@ This, of course, can be done with osBrain:
 Most of the code is similar to the one presented in the :ref:`push_pull`
 example, however you may notice some differences:
 
-#. When runing *Alice*, a new parameter ``base`` is passed to the
+#. When running *Alice*, a new parameter ``base`` is passed to the
    :func:`osbrain.run_agent` function. This means that, instead of
    running the default agent class, the user-defined agent class will be used
    instead. In this case, this class is named ``Greeter``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ and developed by `OpenSistemas <http://www.opensistemas.com>`_.
 Agents run independently as system processes and communicate with each other
 using message passing.
 
-osBrain uses `ØMQ <http://zeromq.org/>`_ for efficient and flexible messsage
+osBrain uses `ØMQ <http://zeromq.org/>`_ for efficient and flexible message
 passing between agents. It also uses `Pyro4 <https://pythonhosted.org/Pyro4/>`_
 to ease the configuration and deployment of complex systems.
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -45,7 +45,7 @@ saying `Hello world!` but, what exactly is happening there?
 
 
 .. note:: The ``ns.shutdown()`` calls in the examples are there because we do
-   not want examples to run indefinetely. For more information on that method,
+   not want examples to run indefinitely. For more information on that method,
    refer to the :ref:`shutting_down` section.
 
 
@@ -55,7 +55,7 @@ saying `Hello world!` but, what exactly is happening there?
 Agents and proxies
 ==================
 
-An agent, in osBrain, is an entity that runs independly from other agents in
+An agent, in osBrain, is an entity that runs independently from other agents in
 the system. When running, it executes the main loop:
 
 - Poll for incoming messages.

--- a/docs/source/timers.rst
+++ b/docs/source/timers.rst
@@ -17,7 +17,7 @@ this, let us modify the :ref:`push_pull` example a bit and make use of the
 Note that if an action takes longer to run than the time available before the
 next execution, the timer will simply fall behind.
 
-.. note:: To be able to start timers on agent initalization, the agent must be
+.. note:: To be able to start timers on agent initialization, the agent must be
    already running, which means you cannot do it from `.on_init()`. Instead,
    you can use `.before_loop()`, which will be called inside the `.run()`
    method and before starting the main loop.

--- a/docs/source/transport_protocol.rst
+++ b/docs/source/transport_protocol.rst
@@ -12,7 +12,7 @@ Transport protocol
 Available transports
 ====================
 
-Althought the default transport protocol is IPC for operating systems that
+Although the default transport protocol is IPC for operating systems that
 provide UNIX domain sockets and TCP for the rest, there are other transport
 protocols that can be used in osBrain:
 

--- a/examples/explicit_serialization.py
+++ b/examples/explicit_serialization.py
@@ -13,7 +13,7 @@ def set_received(agent, message, topic=None):
 
 if __name__ == '__main__':
     # We can define the default serializer through environment variables.
-    # This will be the preferred method from now on, unless overriden.
+    # This will be the preferred method from now on, unless overridden.
     osbrain.config['SERIALIZER'] = 'pickle'
 
     ns = run_nameserver()
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     a0 = run_agent('a0')
     # Agent a1 will ignore the default serialization and use the `raw` option
     # instead. By default, all of `a1` sockets will use `raw` option, unless
-    # overriden.
+    # overridden.
     a1 = run_agent('a1', serializer='raw')
     # Bind a specific socket using json serialization, which will ignore both
     # the global configuration and the per-agent configuration.

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -189,7 +189,7 @@ class Agent():
     _host : str
         Host address where the agent is binding to.
     _uuid : bytes
-        Globally unique identifer for the agent.
+        Globally unique identifier for the agent.
     _running : bool
         Set to `True` if the agent is running (executing the main loop).
     _serializer : str
@@ -580,7 +580,7 @@ class Agent():
         Parameters
         ----------
         alias : str
-            Alias of the socket whose address is to be retreived.
+            Alias of the socket whose address is to be retrieved.
 
         Returns
         -------
@@ -1667,7 +1667,7 @@ class Agent():
             self._loop()
         except Exception as error:
             self._running = False
-            msg = 'An exception occured while running! (%s)\n' % error
+            msg = 'An exception occurred while running! (%s)\n' % error
             msg += format_exception()
             self.log_error(msg)
             raise
@@ -1877,12 +1877,12 @@ class AgentProcess(multiprocessing.Process):
         Raises
         ------
         RuntimeError
-            If an error occured when initializing the daemon.
+            If an error occurred when initializing the daemon.
         """
         super().start()
         status = self._queue.get()
         if not status.startswith('STARTED'):
-            raise RuntimeError('An error occured while creating the daemon!' +
+            raise RuntimeError('An error occurred while creating the daemon!' +
                                '\n===============\n'.join(['', status, '']))
 
         return status.partition(':')[-1]

--- a/osbrain/common.py
+++ b/osbrain/common.py
@@ -29,13 +29,13 @@ def format_exception():
     Represent a traceback exception as a string in which all lines start
     with a `|` character.
 
-    Useful for differenciating remote from local exceptions and exceptions
+    Useful for differentiating remote from local exceptions and exceptions
     that where silenced.
 
     Returns
     -------
     str
-        A formatted string conaining an exception traceback information.
+        A formatted string containing an exception traceback information.
     """
     begin = '\n|>>>>>>>>'
     end = '\n|<<<<<<<<'

--- a/osbrain/helper.py
+++ b/osbrain/helper.py
@@ -31,7 +31,7 @@ def logger_received(logger, message, log_name='log_history_info',
     logger : Proxy
         Proxy to the logger.
     log_name : str, default is `'log_history_info'`
-        The name of the attribue to look for in the logger.
+        The name of the attribute to look for in the logger.
     message : anything
         Message to look for in the log. Can be a partial match. Regular
         expressions are allowed.

--- a/osbrain/nameserver.py
+++ b/osbrain/nameserver.py
@@ -133,14 +133,14 @@ class NameServerProcess(multiprocessing.Process):
         Raises
         ------
         RuntimeError
-            If an error occured when initializing the daemon.
+            If an error occurred when initializing the daemon.
         """
         os.environ['OSBRAIN_NAMESERVER_ADDRESS'] = str(self.addr)
         super().start()
         status = self._queue.get()
         if status == 'STARTED':
             return
-        raise RuntimeError('An error occured while creating the daemon!' +
+        raise RuntimeError('An error occurred while creating the daemon!' +
                            '\n===============\n'.join(['', status, '']))
 
     def agents(self):

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -58,7 +58,7 @@ def test_agent_auto_generated_name(nsproxy):
 def test_early_agent_proxy(nsproxy):
     """
     It must be possible to create a Proxy when the registration of the new
-    agent is imminent, even if it has not occured yet. A timeout will occur
+    agent is imminent, even if it has not occurred yet. A timeout will occur
     in case the agent could not be located.
     """
     agent = AgentProcess('a0')
@@ -152,7 +152,7 @@ def test_run_agent_initial_attributes(nsproxy):
 def test_run_agent_initial_attributes_exception(nsproxy):
     """
     The user can specify a set of attributes to be set in the agent when
-    creating it. If the attribute specified overrites an existing attribute,
+    creating it. If the attribute specified overwrites an existing attribute,
     an exception will be raised.
     """
     with pytest.raises(RuntimeError) as error:

--- a/osbrain/tests/test_agent_async_requests_handlers.py
+++ b/osbrain/tests/test_agent_async_requests_handlers.py
@@ -69,7 +69,7 @@ def test_async_rep_connect_handler_types(nsproxy, handler, check_function):
     We should be able to specify the handler in the `connect` call in
     different ways: method, functions, lambda expressions...
 
-    Note that this handler will be used if not overriden by the `handler`
+    Note that this handler will be used if not overridden by the `handler`
     parameter in the `send` call. However, that is specifically checked in
     other test.
     '''

--- a/osbrain/tests/test_agent_pubsub_topics.py
+++ b/osbrain/tests/test_agent_pubsub_topics.py
@@ -106,7 +106,7 @@ def test_pubsub_topics_raw(nsproxy, serializer):
 
     In the raw version of PUBSUB, we want to replicate the raw message passing
     of ZMQ, in which the topic is passed along the message and it is the
-    responsability of the handler to split them.
+    responsibility of the handler to split them.
     """
     a0 = run_agent('a0')
     a1 = run_agent('a1')

--- a/osbrain/tests/test_agent_sync_publications_handlers.py
+++ b/osbrain/tests/test_agent_sync_publications_handlers.py
@@ -109,7 +109,7 @@ def test_sync_pub_send_handlers(nsproxy, handler, check_function,
 
     addr = server.addr('publish')
 
-    # Use an alternative handler so as to guarantee connection is stablished
+    # Use an alternative handler so as to guarantee connection is established
     client.connect(addr, alias='sub', handler='alternative_receive')
     server.each(0.01, 'publish')
     assert wait_agent_attr(client, name='alternative_received', length=2,

--- a/osbrain/tests/test_bugs.py
+++ b/osbrain/tests/test_bugs.py
@@ -11,7 +11,7 @@ from common import nsproxy  # noqa: F401
 
 def test_timer_recursion(nsproxy):
     """
-    This bug occured with the first implementation of the timer. After
+    This bug occurred with the first implementation of the timer. After
     some iterations the timer would throw an exception when the recursion
     limit was exceeded. Timers should never reach a recursion limit.
     """

--- a/osbrain/tests/test_proxy.py
+++ b/osbrain/tests/test_proxy.py
@@ -23,27 +23,27 @@ def since(t0, passed, tolerance):
     return abs((time.time() - t0) - passed) < tolerance
 
 
-class BussyWorker(Agent):
+class BusyWorker(Agent):
     def on_init(self):
-        self.bind('PULL', alias='pull', handler=self.stay_bussy)
-        self.bussy = False
+        self.bind('PULL', alias='pull', handler=self.stay_busy)
+        self.busy = False
 
-    def stay_bussy(self, delay):
-        self.bussy = True
+    def stay_busy(self, delay):
+        self.busy = True
         time.sleep(delay)
-        self.bussy = False
+        self.busy = False
 
     def listen(self):
         return 'OK'
 
 
-def setup_bussy_worker(nsproxy):
-    worker = run_agent('worker', base=BussyWorker)
+def setup_busy_worker(nsproxy):
+    worker = run_agent('worker', base=BusyWorker)
     boss = run_agent('boss')
     boss.connect(worker.addr('pull'), alias='push')
-    # Make worker bussy for 2 seconds
+    # Make worker busy for 2 seconds
     boss.send('push', 2)
-    assert wait_agent_attr(worker, name='bussy', value=True, timeout=.5)
+    assert wait_agent_attr(worker, name='busy', value=True, timeout=.5)
     return worker
 
 
@@ -141,7 +141,7 @@ def test_agent_proxy_wait_running(nsproxy, timeout):
     assert elapsed <= abs(timeout)
 
 
-def test_agent_proxy_wait_running_0_seconods(nsproxy):
+def test_agent_proxy_wait_running_0_seconds(nsproxy):
     """
     Using `wait_for_running` on a proxy after initialization should block until
     the agent is running or time out.
@@ -211,7 +211,7 @@ def test_agent_run_agent_safe_and_unsafe(nsproxy):
 
 def test_agent_proxy_safe_and_unsafe_parameter(monkeypatch, nsproxy):
     """
-    Using the safe/unsafe parameter when initializating a proxy should allow
+    Using the safe/unsafe parameter when initializing a proxy should allow
     us to override the environment global configuration.
     """
     run_agent('foo')
@@ -236,12 +236,12 @@ def test_agent_proxy_safe_and_unsafe_calls_property_safe(monkeypatch, nsproxy):
     thread is able to process them to avoid concurrency.
     """
     monkeypatch.setitem(osbrain.config, 'SAFE', False)
-    worker = setup_bussy_worker(nsproxy)
+    worker = setup_busy_worker(nsproxy)
     assert not worker._safe
     t0 = time.time()
     assert worker.safe.listen() == 'OK'
     assert since(t0, passed=2., tolerance=0.1)
-    assert not worker.get_attr('bussy')
+    assert not worker.get_attr('busy')
     # Calling a method with `.safe` should not change default behavior
     assert not worker._safe
 
@@ -254,12 +254,12 @@ def test_agent_proxy_safe_and_unsafe_calls_property_unsafe(
     the main thread is able to process them (concurrency is allowed).
     """
     monkeypatch.setitem(osbrain.config, 'SAFE', True)
-    worker = setup_bussy_worker(nsproxy)
+    worker = setup_busy_worker(nsproxy)
     assert worker._safe
     t0 = time.time()
     assert worker.unsafe.listen() == 'OK'
     assert since(t0, passed=0., tolerance=0.1)
-    while worker.get_attr('bussy'):
+    while worker.get_attr('busy'):
         time.sleep(0.01)
     assert since(t0, passed=2., tolerance=0.1)
     # Calling a method with `.unsafe` should not change default behavior
@@ -273,11 +273,11 @@ def test_agent_proxy_safe_and_unsafe_calls_environ_safe(monkeypatch, nsproxy):
     thread is able to process them to avoid concurrency.
     """
     monkeypatch.setitem(osbrain.config, 'SAFE', True)
-    worker = setup_bussy_worker(nsproxy)
+    worker = setup_busy_worker(nsproxy)
     t0 = time.time()
     assert worker.listen() == 'OK'
     assert since(t0, passed=2., tolerance=0.1)
-    assert not worker.get_attr('bussy')
+    assert not worker.get_attr('busy')
 
 
 def test_agent_proxy_safe_and_unsafe_calls_environ_unsafe(
@@ -288,11 +288,11 @@ def test_agent_proxy_safe_and_unsafe_calls_environ_unsafe(
     the main thread is able to process them (concurrency is allowed).
     """
     monkeypatch.setitem(osbrain.config, 'SAFE', False)
-    worker = setup_bussy_worker(nsproxy)
+    worker = setup_busy_worker(nsproxy)
     t0 = time.time()
     assert worker.listen() == 'OK'
     assert since(t0, passed=0., tolerance=0.1)
-    while worker.get_attr('bussy'):
+    while worker.get_attr('busy'):
         time.sleep(0.01)
     assert since(t0, passed=2., tolerance=0.1)
 


### PR DESCRIPTION
Since the spell checker integration may take some time, I thought it would be useful to run it manually once to fix any typos we may have.

At least now we're (hopefully) free of spelling errors :tada: :tada: :tada: