### PR TITLE
Check no print statements left in source code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
             'flake8',
             'flake8-bugbear',
             'flake8-per-file-ignores',
+            'flake8-print',
             'flake8-quotes',
             'pep8-naming',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,13 @@ envlist =
 [flake8]
 per-file-ignores =
     docs/source/conf.py: E121,E122,E265,E501
+    examples/*.py: T001
     osbrain/__init__.py: E402,F401
     osbrain/tests/test_*.py: F811
 inline-quotes = single
 multiline-quotes = double
 max-complexity = 5
-select = C,E,F,W,N,B,B902,Q
+select = C,E,F,W,N,B,B902,Q,T
 
 [testenv]
 deps =


### PR DESCRIPTION
In #294 I accidentally uploaded a commit with some `print()` statements.

This plugin checks there are none left in the source code files. A little mistake that we could some day make...

https://github.com/search?q=remove+print&type=Commits