### PR TITLE
Fixed code example typo - renamed param name 'handlers' to 'handler'

### DIFF
--- a/examples/pub_sub_more_on_filter.py
+++ b/examples/pub_sub_more_on_filter.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
     time.sleep(2)
 
     bob.unsubscribe('listener', 'a')
-    bob.subscribe('listener', handlers={'b': log_b})
+    bob.subscribe('listener', handler={'b': log_b})
 
     time.sleep(2)
 


### PR DESCRIPTION
Fixed a typo in a code example. The old code would throw a runtime exception:
`ERROR [2018-04-22 23:55:28.625972] (Bob): An exception occurred while running! (subscribe() got an unexpected keyword argument 'handlers')
`