### PR TITLE
Avoid using version 17 of PyZMQ for now

### DIFF
--- a/osbrain/__init__.py
+++ b/osbrain/__init__.py
@@ -39,7 +39,7 @@ else:
     config['IPC_DIR'].mkdir(exist_ok=True, parents=True)
 
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 
 from .agent import Agent, AgentProcess, run_agent
 from .nameserver import NameServer, run_nameserver

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=['osbrain'],
     install_requires=[
         'Pyro4>=4.48',
-        'pyzmq>=15.2.0',
+        'pyzmq>=15.2.0,<17.0.0',
         'dill>=0.2.0,!=0.2.7',
         'cloudpickle>=0.4.0',
     ] + install_requires_compat,


### PR DESCRIPTION
See https://github.com/zeromq/pyzmq/issues/1170.

The test suite [breaks](https://travis-ci.org/opensistemas-hub/osbrain/builds/405590284) with PyZMQ v17 while [passes](https://travis-ci.org/opensistemas-hub/osbrain/builds/407155149) when `pyzmq` is set to <v17 (v16).