### PR TITLE
remove b' from ipc socket names

### DIFF
--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -806,7 +806,7 @@ class Agent():
         if transport == 'tcp':
             return self._bind_socket_tcp(socket, addr=addr)
         if not addr:
-            addr = str(unique_identifier())
+            addr = unique_identifier().decode('ascii')
         if transport == 'ipc':
             addr = config['IPC_DIR'] / addr
         socket.bind('%s://%s' % (transport, addr))


### PR DESCRIPTION
`str(b"x")` is `b"x"` so ipc sockets were being created as `~/.osbrain_ipc/b'37a76fda9a264...'`. Instead, cast bytes to str via the `bytes.decode()` method.