### PR TITLE
fix tests with pyzmq 17

### DIFF
--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -1772,6 +1772,15 @@ class Agent():
         """
         linger = get_linger(linger)
         socket.close(linger=linger)
+        address = self._address[socket]
+        if address.transport == 'ipc':
+            # cleanup ipc sockets
+            try:
+                os.unlink(address.address)
+            except FileNotFoundError:
+                # someone else already removed it,
+                # e.g. libzmq < 4.2
+                pass
 
     def close(self, alias, linger=None):
         """

--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -1774,9 +1774,13 @@ class Agent():
         socket.close(linger=linger)
         address = self._address[socket]
         if address.transport == 'ipc':
+            if isinstance(address, AgentChannel):
+                path = address.receiver.address or address.sender.address
+            else:
+                path = address.address
             # cleanup ipc sockets
             try:
-                os.unlink(address.address)
+                os.unlink(path)
             except FileNotFoundError:
                 # someone else already removed it,
                 # e.g. libzmq < 4.2

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=['osbrain'],
     install_requires=[
         'Pyro4>=4.48',
-        'pyzmq>=15.2.0,<17.0.0',
+        'pyzmq>=15.2.0',
         'dill>=0.2.0,!=0.2.7',
         'cloudpickle>=0.4.0',
     ] + install_requires_compat,


### PR DESCRIPTION
libzmq 4.2, which is bundled with pyzmq 17 but can be used with ~any version of pyzmq, [does not cleanup ipc files](https://github.com/zeromq/libzmq/issues/2764) after closing sockets. The fix is to cleanup these files after closing the binding socket.

closes #303