### PR TITLE
Fix PyZMQ 17 compatibility issues

### DIFF
--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -1772,6 +1772,19 @@ class Agent():
         """
         linger = get_linger(linger)
         socket.close(linger=linger)
+        address = self._address[socket]
+        if address.transport == 'ipc':
+            if isinstance(address, AgentChannel):
+                path = address.receiver.address or address.sender.address
+            else:
+                path = address.address
+            # cleanup ipc sockets
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                # someone else already removed it,
+                # e.g. libzmq < 4.2
+                pass
 
     def close(self, alias, linger=None):
         """

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=['osbrain'],
     install_requires=[
         'Pyro4>=4.48',
-        'pyzmq>=15.2.0,<17.0.0',
+        'pyzmq>=15.2.0',
         'dill>=0.2.0,!=0.2.7',
         'cloudpickle>=0.4.0',
     ] + install_requires_compat,


### PR DESCRIPTION
By manually cleaning IPC files after closing sockets.

Fixes #303. Closes #305.