### PR TITLE
Fix compatibility with pytest 3.8.0

### DIFF
--- a/osbrain/tests/test_agent_transport.py
+++ b/osbrain/tests/test_agent_transport.py
@@ -104,7 +104,7 @@ def test_agent_bind_given_address_tcp(nsproxy):
 
 
 @skip_windows_ipc
-def test_agent_ipc_from_different_folders(nsproxy):
+def test_agent_ipc_from_different_folders(nsproxy, monkeypatch):
     """
     IPC should work well even when agents are run from different folders.
     """
@@ -117,14 +117,14 @@ def test_agent_ipc_from_different_folders(nsproxy):
     assert dira != dirb
 
     # First agent run for directory `a`
-    os.chdir(dira)
+    monkeypatch.chdir(dira)
     a = run_agent('a', base=Wdagent)
     random_addr = a.bind('PULL', transport='ipc', handler=append_received)
     set_addr = a.bind('PULL', addr='qwer', transport='ipc',
                       handler=append_received)
 
     # Second agent run for directory `b`
-    os.chdir(dirb)
+    monkeypatch.chdir(dirb)
     b = run_agent('b', base=Wdagent)
     b.connect(random_addr, alias='random')
     b.connect(set_addr, alias='set')

--- a/osbrain/tests/test_agent_transport.py
+++ b/osbrain/tests/test_agent_transport.py
@@ -136,6 +136,7 @@ def test_agent_ipc_from_different_folders(nsproxy, monkeypatch):
     set_received = wait_agent_attr(a, data='bar', timeout=1)
 
     # Clean directories
+    monkeypatch.undo()
     rmtree(dira)
     rmtree(dirb)
 


### PR DESCRIPTION
As discussed in https://github.com/pytest-dev/pytest/issues/3973, pytest 3.8.0
introduced some code that ends up checking the `cwd` by accident. One of
the tests in your test suites changes the `cwd` to a temporary directory, and
this blows up some tests after it.

This change uses the `monkeypatch` fixture to safe cwd-switching, by
restoring it to the original value at the end of the test.