### PR TITLE
Fix linting errors

### DIFF
--- a/osbrain/agent.py
+++ b/osbrain/agent.py
@@ -1896,7 +1896,7 @@ class AgentProcess(multiprocessing.Process):
                 ns = NSProxy(self.nsaddr)
                 ns.remove(self.name)
                 ns.release()
-            except PyroError as error:
+            except PyroError:
                 time.sleep(0.1)
                 continue
             break

--- a/osbrain/proxy.py
+++ b/osbrain/proxy.py
@@ -208,8 +208,8 @@ class Proxy(Pyro4.core.Proxy):
         self._next_oneway = True
         return self
 
-    def _pyroInvoke(self, methodname, args, kwargs,
-                    flags=0, objectId=None):  # flake8: noqa
+    def _pyroInvoke(self, methodname, args, kwargs,  # noqa: N802, N803
+                    flags=0, objectId=None):
         """
         Wrapper around `_remote_call` to safely execute methods on remote
         objects.
@@ -246,7 +246,8 @@ class Proxy(Pyro4.core.Proxy):
                 methodname not in ('run', 'get_attr', 'kill', 'safe_call',
                                    'concurrent', 'is_running'))
 
-    def _remote_call(self, methodname, args, kwargs, flags, objectId):
+    def _remote_call(self, methodname, args, kwargs, flags,  # noqa: N803
+                     objectId):
         """
         Call a remote method from the proxy.
         """
@@ -293,7 +294,7 @@ class Proxy(Pyro4.core.Proxy):
         """
         for method in args:
             self._pyroMethods.add(method.__name__)
-        for name, method in kwargs.items():
+        for name, _ in kwargs.items():
             self._pyroMethods.add(name)
 
     def _set_new_available_attributes(self, kwargs):

--- a/osbrain/tests/test_logging.py
+++ b/osbrain/tests/test_logging.py
@@ -24,7 +24,7 @@ def test_logging_level(nsproxy):
     while not len(logger.get_attr('log_history')):
         i += 1
         agent.log_info(i)
-    assert logger_received(logger, message='\): %s' % i, position=-1)
+    assert logger_received(logger, message=r'\): %s' % i, position=-1)
     before = len(logger.get_attr('log_history'))
     agent.log_info('some information')
     agent.log_warning('some warning')


### PR DESCRIPTION
Flake8 was updated and a bunch of new errors started showing up: https://travis-ci.org/opensistemas-hub/osbrain/jobs/452151480

Apparently we weren't using `noqa` correctly either. `flake8: noqa` would ignore warnings for the entire file, regardless of whether we used them in a single line or not. This behavior [has been changed](https://gitlab.com/pycqa/flake8/merge_requests/219) in the new version, and that uncovered a couple more errors.