### PR TITLE
Fix linting errors

### DIFF
--- a/osbrain/proxy.py
+++ b/osbrain/proxy.py
@@ -208,8 +208,8 @@ class Proxy(Pyro4.core.Proxy):
         self._next_oneway = True
         return self
 
-    def _pyroInvoke(self, methodname, args, kwargs,  # noqa: N802, N803
-                    flags=0, objectId=None):
+    def _pyroInvoke(self, methodname, args, kwargs,  # noqa: N802
+                    flags=0, objectId=None):  # noqa: N803
         """
         Wrapper around `_remote_call` to safely execute methods on remote
         objects.
@@ -246,8 +246,8 @@ class Proxy(Pyro4.core.Proxy):
                 methodname not in ('run', 'get_attr', 'kill', 'safe_call',
                                    'concurrent', 'is_running'))
 
-    def _remote_call(self, methodname, args, kwargs, flags,  # noqa: N803
-                     objectId):
+    def _remote_call(self, methodname, args, kwargs, flags,
+                     objectId):  # noqa: N803
         """
         Call a remote method from the proxy.
         """

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         'lint': [
             'flake8',
             'flake8-bugbear',
-            'flake8-per-file-ignores',
             'flake8-print',
             'flake8-quotes',
             'pep8-naming',


### PR DESCRIPTION
Two things:
1. `pep8-naming` was updated and now `flake8` (sadly) works as expected, which means it doesn't support using a single `noqa` to ignore the entire function definition. Now you need separate comments for every affected line. I opened [an issue](https://gitlab.com/pycqa/flake8/issues/506) but they told me they're not going to implement it and closed it immediately.

2. The `per-file-ignores` plugin was integrated into `flake8` and it's not necessary anymore.