### PR TITLE
Create common echo handler

### DIFF
--- a/osbrain/tests/common.py
+++ b/osbrain/tests/common.py
@@ -21,3 +21,7 @@ def append_received(agent, message, topic=None):
 
 def set_received(agent, message, topic=None):
     agent.received = message
+
+
+def echo_handler(agent, message):
+    return message

--- a/osbrain/tests/test_agent.py
+++ b/osbrain/tests/test_agent.py
@@ -25,6 +25,7 @@ from osbrain.helper import sync_agent_logger
 from osbrain.helper import wait_agent_attr
 
 from .common import append_received
+from .common import echo_handler
 from .common import set_received
 from .common import skip_windows_any_port
 from .common import skip_windows_port_reuse
@@ -425,16 +426,13 @@ def test_agent_connect_repeat(nsproxy):
     connected to just before. When no new handler is given, the agent simply
     adds a new alias. Both aliases should work as expected.
     """
-    def rep_handler(agent, message):
-        return 'OK'
-
     server = run_agent('a0')
     client = run_agent('a1')
-    addr = server.bind('REP', 'reply', rep_handler)
+    addr = server.bind('REP', 'reply', echo_handler)
     client.connect(addr, alias='request0')
     client.connect(addr, alias='request1')
-    assert client.send_recv('request0', 'Hello world') == 'OK'
-    assert client.send_recv('request1', 'Hello world') == 'OK'
+    assert client.send_recv('request0', 'Hello world') == 'Hello world'
+    assert client.send_recv('request1', 'Hello world') == 'Hello world'
 
 
 def test_agent_connect_repeat_new_handler(nsproxy):

--- a/osbrain/tests/test_agent_req_rep.py
+++ b/osbrain/tests/test_agent_req_rep.py
@@ -8,17 +8,16 @@ from osbrain import run_logger
 from osbrain.helper import logger_received
 from osbrain.helper import sync_agent_logger
 
+from .common import echo_handler
+
 
 def test_return(nsproxy):
     """
     REQ-REP pattern using a handler that returns a value.
     """
-    def rep_handler(agent, message):
-        return message
-
     a0 = run_agent('a0')
     a1 = run_agent('a1')
-    addr = a0.bind('REP', handler=rep_handler)
+    addr = a0.bind('REP', handler=echo_handler)
     a1.connect(addr, alias='request')
     response = a1.send_recv('request', 'Hello world')
     assert response == 'Hello world'

--- a/osbrain/tests/test_agent_serialization.py
+++ b/osbrain/tests/test_agent_serialization.py
@@ -14,6 +14,7 @@ from osbrain.agent import deserialize_message
 from osbrain.agent import serialize_message
 from osbrain.helper import wait_agent_attr
 
+from .common import echo_handler
 from .common import set_received
 
 
@@ -135,13 +136,10 @@ def test_reqrep_raw_zmq_outside(nsproxy):
     """
     Simple request-reply pattern between an agent and a direct ZMQ connection.
     """
-    def rep_handler(agent, message):
-        return message
-
     # Create an osBrain agent that will receive the message
     a1 = run_agent('a1')
     a1.set_attr(received=None)
-    addr = a1.bind('REP', transport='tcp', handler=rep_handler,
+    addr = a1.bind('REP', transport='tcp', handler=echo_handler,
                    serializer='raw')
 
     # Create a raw ZeroMQ REQ socket


### PR DESCRIPTION
Fixes #333 

The issue was that the socket was not being removed from the poller's list before being closed, so the next time the poller tried to check on its sockets, the closed ones would still be there and that would cause a connection error.

I don't know why this is needed on Windows but not on Linux, but this should fix the problem.

By the way, I can't believe we didn't have a test where we close a connected socket yet 🤷‍♂ .